### PR TITLE
fix(bitwarden-pm): deserialize TwoFactorProviders from either number or string

### DIFF
--- a/rosec-bitwarden-pm/src/api.rs
+++ b/rosec-bitwarden-pm/src/api.rs
@@ -484,12 +484,43 @@ struct LoginErrorResponse {
     error: Option<String>,
     #[serde(alias = "error_description")]
     error_description: Option<String>,
-    #[serde(alias = "TwoFactorProviders")]
+    #[serde(alias = "TwoFactorProviders", deserialize_with = "deser_two_factor_providers")]
     two_factor_providers: Option<Vec<u8>>,
     /// Per-provider metadata.  Keyed by provider code (as a string).
     /// Provider 1 (email) has `{ "Email": "j***@example.com" }`.
     #[serde(alias = "TwoFactorProviders2", default)]
     two_factor_providers2: Option<HashMap<String, serde_json::Value>>,
+}
+
+/// Deserialize TwoFactorProviders from either numeric or string provider codes.
+fn deser_two_factor_providers<'de, D>(de: D) -> Result<Option<Vec<u8>>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum ProviderCode {
+        Num(u8),
+        Str(String),
+    }
+
+    let raw = Option::<Vec<ProviderCode>>::deserialize(de)?;
+    let Some(raw) = raw else {
+        return Ok(None);
+    };
+
+    let mut out = Vec::with_capacity(raw.len());
+    for code in raw {
+        match code {
+            ProviderCode::Num(v) => out.push(v),
+            ProviderCode::Str(s) => {
+                let parsed = s.parse::<u8>().map_err(serde::de::Error::custom)?;
+                out.push(parsed);
+            }
+        }
+    }
+
+    Ok(Some(out))
 }
 
 /// Refresh response — tokens are sensitive.
@@ -611,6 +642,39 @@ pub struct SyncUri {
     #[serde(alias = "Match", alias = "match")]
     #[allow(dead_code)]
     pub match_type: Option<u8>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LoginErrorResponse;
+
+    #[test]
+    fn login_error_parses_two_factor_providers_as_strings() {
+        let payload = r#"{
+            "error":"invalid_grant",
+            "error_description":"Two factor required.",
+            "TwoFactorProviders":["0","7","3"]
+        }"#;
+
+        let parsed: LoginErrorResponse =
+            serde_json::from_str(payload).expect("login error should deserialize");
+
+        assert_eq!(parsed.two_factor_providers, Some(vec![0, 7, 3]));
+    }
+
+    #[test]
+    fn login_error_parses_two_factor_providers_as_numbers() {
+        let payload = r#"{
+            "error":"invalid_grant",
+            "error_description":"Two factor required.",
+            "TwoFactorProviders":[0,7,3]
+        }"#;
+
+        let parsed: LoginErrorResponse =
+            serde_json::from_str(payload).expect("login error should deserialize");
+
+        assert_eq!(parsed.two_factor_providers, Some(vec![0, 7, 3]));
+    }
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
- deserialize TwoFactorProviders to be compatible with Bitwarden API
- intentionally left number format too because I don't know if other APIs or older versions really do return numbers
- tested with Bitwarden SaaS personal account, haven't tested with Vaultwarden, older API versions, etc.

Warning: this code is AI slop, please treat as bug report and mock code.
I don't know rust well enough to confidently review this auto-generated code.
And I apologize if this wastes more than it contributes; feel free to tell me off, I don't get offended.

### Motivation

When adding Bitwarden SaaS account using bitwarden-pm provider, user is correctly asked for master password. 
After entering correct password if account has **any** 2FA type enabled, user is presented with an error instead of 2FA prompt. 

User-facing error:
> Error: org.freedesktop.DBus.Error.Failed: auth_provider_with_tty error: auth failed for 'bw': org.freedesktop.DBus.Error.Failed: auth_failed

Service's log line:
> WARN extism::pdk: unlock failed: authentication failed: login failed (400): {"error":"invalid_grant","error_description":"Two factor required.","TwoFactorProviders":["0","7","3"],"TwoFactorProviders2":{"0":null,"7":{"challenge":"[ANONYMIZED]","timeout":60000,"rpId":"vault.bitwarden.com","allowCredentials":[{"type":"public-key","id":"[ANONYMIZED]"}],"userVerification":"discouraged","extensions":{"appid":"https://vault.bitwarden.com/app-id.json","uvm":true},"status":"ok","errorMessage":""},"3":{"Nfc":true}},"MasterPasswordPolicy":{"Object":"masterPasswordPolicy"}} plugin="db243ebf-97a4-4111-b7e7-dac39db3a0a1"
