### PR TITLE
fix: make SSH RSA keys work despite upstream bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4654,8 +4654,7 @@ dependencies = [
 [[package]]
 name = "ssh-cipher"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caac132742f0d33c3af65bfcde7f6aa8f62f0e991d80db99149eb9d44708784f"
+source = "git+https://github.com/RustCrypto/SSH?branch=stable#68e8589194942f4eedcdbf86669076073c997d32"
 dependencies = [
  "aes",
  "aes-gcm",
@@ -4671,8 +4670,7 @@ dependencies = [
 [[package]]
 name = "ssh-encoding"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
+source = "git+https://github.com/RustCrypto/SSH?branch=stable#68e8589194942f4eedcdbf86669076073c997d32"
 dependencies = [
  "base64ct",
  "pem-rfc7468",
@@ -4682,8 +4680,7 @@ dependencies = [
 [[package]]
 name = "ssh-key"
 version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
+source = "git+https://github.com/RustCrypto/SSH?branch=stable#68e8589194942f4eedcdbf86669076073c997d32"
 dependencies = [
  "bcrypt-pbkdf",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,3 +71,10 @@ signature = "2"
 
 # Dev dependencies for git hooks
 husky-rs = "0.3"
+
+# Patch ssh-key and ssh-encoding with the fixed version from the upstream 'stable' branch.
+# Work around RSA signing bug in ssh-key 0.6.7.
+# Remove when ssh-key 0.6.8 is released with the fix.
+[patch.crates-io]
+ssh-key = { git = "https://github.com/RustCrypto/SSH", branch = "stable", package = "ssh-key" }
+ssh-encoding = { git = "https://github.com/RustCrypto/SSH", branch = "stable", package = "ssh-encoding" }

--- a/rosec-fuse/src/fs.rs
+++ b/rosec-fuse/src/fs.rs
@@ -252,9 +252,9 @@ fn make_attr(ino: INodeNo, kind: FileType, size: u64, nlink: u32, mtime: SystemT
         crtime: UNIX_EPOCH,
         kind,
         perm: if kind == FileType::Directory {
-            0o555
+            0o500
         } else {
-            0o444
+            0o400
         },
         nlink,
         uid,


### PR DESCRIPTION
- tighten FUSE permissions for SSH config files and public keys
  - no reason for those to be group/world readable
- patch ssh-key and ssh-encoding to the upstream RustCrypto SSH 'stable' branch

### Motivation

Work around broken RSA signing in ssh-key 0.6.7 which causes RSA keys to be unusable.
Ref. [RustCrypto/SSH/pull/318](https://github.com/RustCrypto/SSH/pull/318)
Both patches should be removed once upstream publishes version 0.6.8.
