### PR TITLE
fix: reject unsigned plugins by default

### DIFF
--- a/rosec-core/src/config.rs
+++ b/rosec-core/src/config.rs
@@ -43,9 +43,7 @@ pub struct ServiceConfig {
     pub wasm_prefer: WasmPreference,
     /// Controls signature verification of WASM provider plugins.
     ///
-    /// - `"if-present"` (default) — verify if `.wasm.sig` exists; skip with
-    ///   warning if absent; never load a plugin with an invalid signature
-    /// - `"required"` — reject plugins without a valid `.wasm.sig`
+    /// - `"required"` (default) — reject plugins without a valid `.wasm.sig`
     /// - `"disabled"` — skip all verification (local development only)
     #[serde(default)]
     pub wasm_verify: WasmVerify,

--- a/rosec-core/src/lib.rs
+++ b/rosec-core/src/lib.rs
@@ -1184,12 +1184,10 @@ pub enum WasmPreference {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum WasmVerify {
-    /// Verify signature if a `.wasm.sig` file exists; warn and skip if absent.
-    /// Unverified plugins (missing or invalid sig) are never loaded.
-    #[default]
-    IfPresent,
     /// Signature is required.  Plugins without a valid `.wasm.sig` are
     /// rejected and never loaded.
+    #[default]
+    #[serde(alias = "if-present")]
     Required,
     /// Signature verification is disabled.  All plugins are loaded regardless.
     /// Only use for local development builds.

--- a/rosec-wasm/src/discovery.rs
+++ b/rosec-wasm/src/discovery.rs
@@ -307,7 +307,7 @@ fn should_replace(
 enum VerifyOutcome {
     /// Signature present and verified.
     Verified,
-    /// Verification was not performed (disabled or sig absent under `IfPresent`).
+    /// Verification was not performed (disabled).
     /// The plugin may still be loaded.
     NotVerified { reason: &'static str },
     /// Plugin should NOT be loaded (e.g. unsigned under `Required`).
@@ -315,10 +315,6 @@ enum VerifyOutcome {
 }
 
 /// Check the signature of a `.wasm` file according to the configured policy.
-///
-/// Returns `Ok(Verified)` if the signature is present and valid,
-/// `Ok(Skipped)` if verification is disabled or the sig is absent under
-/// `IfPresent`, or `Err` if the signature is present but invalid.
 fn verify_plugin(wasm_path: &Path, verify: WasmVerify) -> VerifyOutcome {
     if verify == WasmVerify::Disabled {
         return VerifyOutcome::NotVerified { reason: "disabled" };
@@ -327,17 +323,8 @@ fn verify_plugin(wasm_path: &Path, verify: WasmVerify) -> VerifyOutcome {
     let sig_path = wasm_path.with_extension("wasm.minisig");
 
     if !sig_path.exists() {
-        return match verify {
-            WasmVerify::IfPresent => VerifyOutcome::NotVerified {
-                reason: "sig-not-present",
-            },
-            WasmVerify::Required => VerifyOutcome::Rejected {
-                reason: format!(
-                    "signature file '{}' not found (wasm_verify = required)",
-                    sig_path.display(),
-                ),
-            },
-            WasmVerify::Disabled => unreachable!(),
+        return VerifyOutcome::Rejected {
+            reason: format!("signature file '{}' not found", sig_path.display()),
         };
     }
 


### PR DESCRIPTION
The `IfPresent` policy was documented as saying that unverified plugins would never be loaded. But the code was actually happily loading any unsigned `.wasm` plugin withoug a sig file.

So this pr just updates the code to match the docs.

Also there was some unnecisary vars, which were just doing the same thing. So I collapsed the `Required` into `IfPresent` and renamed the new strict default. But for now `wasm-verify = "if-present"` still parses via serde alias. 

All tests and checks pass for me, but I'm not super familiar with the codebase, so proper human review still needed. I'll also wait to see if the CI raises anything missed on my system!

Btw, this is fix for the issue referenced in https://github.com/Lissy93/awesome-privacy/pull/533