### PR TITLE
build(rosec-prompt): bump ashpd 0.10→0.12 and rqrr 0.8→0.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,14 +228,14 @@ checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
 name = "ashpd"
-version = "0.10.3"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3d60bee1a1d38c2077030f4788e1b4e31058d2e79a8cfc8f2b440bd44db290"
+checksum = "33a3c86f3fd70c0ffa500ed189abfa90b5a52398a45d5dc372fcc38ebeb7a645"
 dependencies = [
  "enumflags2",
  "futures-channel",
  "futures-util",
- "rand 0.8.5",
+ "rand 0.9.4",
  "serde",
  "serde_repr",
  "tokio",
@@ -2193,8 +2193,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -2204,6 +2202,8 @@ version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
  "serde",
  "serde_core",
@@ -3027,11 +3027,11 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -4192,8 +4192,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
+ "rand_chacha 0.3.1",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -4218,12 +4228,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -4699,9 +4728,9 @@ dependencies = [
 
 [[package]]
 name = "rqrr"
-version = "0.8.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48eaf9c75f2a8f231b09036c115a45a9845313f7faa6a39fa45a2a2bd06a27c7"
+checksum = "ffbe87d9e8db95652c25ded2418150e00b08c2fde09e23ec15896d2c470c6631"
 dependencies = [
  "g2p",
  "image",

--- a/rosec-prompt/Cargo.toml
+++ b/rosec-prompt/Cargo.toml
@@ -22,6 +22,9 @@ zeroize = { workspace = true }
 
 # QR code scanning
 image = { version = "0.25", default-features = false, features = ["png"] }
-rqrr = "0.8"
-ashpd = "0.10"
+rqrr = "0.10"
+# Pinned to 0.12.x: ashpd 0.13 split portals behind per-feature flags, but its
+# `screenshot` feature is broken (uses serde_repr without enabling the dep —
+# uncompilable in isolation). Revisit 0.13 once that upstream bug is fixed.
+ashpd = "0.12"
 tokio = { workspace = true }


### PR DESCRIPTION
Investigates and upgrades the three outstanding breaking 0.x bumps in `rosec-prompt`. Two are upgraded cleanly; one is deliberately left with rationale.

## ✅ rqrr 0.8.0 → 0.10.1
Standalone (only rosec-prompt), used for QR decoding in `gui/qr.rs`. No source changes; still accepts `image 0.25`.

## ✅ ashpd 0.10.3 → 0.12.3
Standalone, used for the Screenshot portal in `gui/qr.rs`. No source changes (builder API unchanged).

**Why 0.12, not 0.13:** ashpd 0.13 split each portal behind its own feature flag, but its `screenshot` feature is **broken upstream** — `screenshot.rs` imports `serde_repr` unconditionally while `screenshot = []` doesn't enable the dep, so it can't compile in isolation. 0.11/0.12 keep portals ungated and build cleanly. Worth revisiting 0.13 once the upstream feature bug is fixed.

## ⏸️ cosmic-text 0.12 → 0.19: intentionally not bumped
`cosmic-text` is pinned by **iced 0.13** (`iced_graphics 0.13` → `cosmic-text 0.12`), and rosec-prompt only uses it directly for standalone text measurement in `helpers.rs`. Bumping the direct dep to 0.19 would:
- duplicate the entire font stack (two copies of fontdb/rustybuzz/swash/ttf-parser), and
- require rewriting the measurement code against 0.12→0.19 API changes.

Advancing it properly means upgrading **iced** itself — a large migration across the ~3k-line GUI (broad API surface: `Task`, `Element`, `Subscription`, widgets, styling), and **iced 0.14 only reaches cosmic-text 0.15** anyway (not 0.19). That's a separate project, out of scope here.

## Verification (local)
- `cargo build`/`check --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo audit` green ✅
- MSRV 1.91 `--locked` check ✅
- No duplicated `cosmic-text` in the lockfile