### PR TITLE
build(rosec-prompt): migrate to iced 0.14 (+ fix Tab, clipboard, QR under sandbox)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,15 +194,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "approx"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,12 +556,6 @@ dependencies = [
  "xdg-home",
  "zbus",
 ]
-
-[[package]]
-name = "by_address"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
 
 [[package]]
 name = "bytemuck"
@@ -1042,22 +1027,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "cosmic-text"
-version = "0.12.1"
+name = "core_maths"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59fd57d82eb4bfe7ffa9b1cec0c05e2fd378155b47f255a67983cb4afe0e80c2"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "cosmic-text"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173852283a9a57a3cbe365d86e74dc428a09c50421477d5ad6fe9d9509e37737"
 dependencies = [
  "bitflags 2.11.0",
  "fontdb",
+ "harfrust",
+ "linebender_resource_handle",
  "log",
  "rangemap",
- "rayon",
  "rustc-hash 1.1.0",
- "rustybuzz",
  "self_cell",
+ "skrifa 0.37.0",
+ "smol_str",
  "swash",
  "sys-locale",
- "ttf-parser 0.21.1",
  "unicode-bidi",
  "unicode-linebreak",
  "unicode-script",
@@ -1305,10 +1300,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctor-lite"
-version = "0.1.2"
+name = "ctor"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e162d0c2e2068eb736b71e5597eff0b9944e6b973cd9f37b6a288ab9bf20e300"
+checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
+dependencies = [
+ "dtor",
+]
 
 [[package]]
 name = "ctr"
@@ -1458,44 +1456,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
 
 [[package]]
-name = "drm"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "drm-ffi",
- "drm-fourcc",
- "libc",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "drm-ffi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
-dependencies = [
- "drm-sys",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "drm-fourcc"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
-
-[[package]]
-name = "drm-sys"
+name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
-dependencies = [
- "libc",
- "linux-raw-sys 0.9.4",
-]
+checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "ecdsa"
@@ -1716,12 +1680,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fast-srgb8"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
-
-[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1805,9 +1763,18 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "font-types"
-version = "0.7.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3971f9a5ca983419cdc386941ba3b9e1feba01a0ab888adf78739feb2798492"
+checksum = "39a654f404bbcbd48ea58c617c2993ee91d1cb63727a37bf2323a4edeed1b8c5"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "font-types"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
 dependencies = [
  "bytemuck",
 ]
@@ -1823,16 +1790,16 @@ dependencies = [
 
 [[package]]
 name = "fontdb"
-version = "0.16.2"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0299020c3ef3f60f526a4f64ab4a3d4ce116b1acbf24cdd22da0068e5d81dc3"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
 dependencies = [
  "fontconfig-parser",
  "log",
  "memmap2",
  "slotmap",
  "tinyvec",
- "ttf-parser 0.20.0",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -1904,7 +1871,7 @@ dependencies = [
  "nix",
  "num_enum",
  "page_size",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pkg-config",
  "ref-cast",
  "smallvec",
@@ -2188,6 +2155,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "harfrust"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92c020db12c71d8a12a3fe7607873cade3a01a6287e29d540c8723276221b9d8"
+dependencies = [
+ "bitflags 2.11.0",
+ "bytemuck",
+ "core_maths",
+ "read-fonts 0.35.0",
+ "smallvec",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2402,42 +2382,54 @@ dependencies = [
 
 [[package]]
 name = "iced"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88acfabc84ec077eaf9ede3457ffa3a104626d79022a9bf7f296093b1d60c73f"
+checksum = "000e01026c93ba643f8357a3db3ada0e6555265a377f6f9291c472f6dd701fb3"
 dependencies = [
  "iced_core",
+ "iced_debug",
  "iced_futures",
  "iced_renderer",
+ "iced_runtime",
  "iced_widget",
  "iced_winit",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "iced_core"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0013a238275494641bf8f1732a23a808196540dc67b22ff97099c044ae4c8a1c"
+checksum = "91ab1937d699403e7e69252ae743a902bcee9f4ab2052cc4c9a46fcf34729d85"
 dependencies = [
  "bitflags 2.11.0",
  "bytes",
  "glam",
+ "lilt",
  "log",
  "num-traits",
- "once_cell",
- "palette",
  "rustc-hash 2.1.2",
  "smol_str",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
 [[package]]
-name = "iced_futures"
-version = "0.13.2"
+name = "iced_debug"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c04a6745ba2e80f32cf01e034fd00d853aa4f4cd8b91888099cb7aaee0d5d7c"
+checksum = "25035ab0215a620e53f4103e36fc4e59a1fb2817e4bfc38a30ad27b4202ea0be"
+dependencies = [
+ "iced_core",
+ "iced_futures",
+ "log",
+]
+
+[[package]]
+name = "iced_futures"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c0c85ccad42dfbec7293c36c018af0ea0dbcc52d137a4a9a0b0f6822a3fdf0a"
 dependencies = [
  "futures",
  "iced_core",
@@ -2445,14 +2437,14 @@ dependencies = [
  "rustc-hash 2.1.2",
  "tokio",
  "wasm-bindgen-futures",
- "wasm-timer",
+ "wasmtimer",
 ]
 
 [[package]]
 name = "iced_graphics"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba25a18cfa6d5cc160aca7e1b34f73ccdff21680fa8702168c09739767b6c66f"
+checksum = "234ca1c2cec4155055f68fa5fad1b5242c496ac8238d80a259bca382fb44a102"
 dependencies = [
  "bitflags 2.11.0",
  "bytemuck",
@@ -2461,46 +2453,56 @@ dependencies = [
  "iced_core",
  "iced_futures",
  "log",
- "once_cell",
  "raw-window-handle",
  "rustc-hash 2.1.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unicode-segmentation",
 ]
 
 [[package]]
-name = "iced_renderer"
-version = "0.13.0"
+name = "iced_program"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73558208059f9e622df2bf434e044ee2f838ce75201a023cf0ca3e1244f46c2a"
+checksum = "6dfafec2947cda688d8eb00dac337ba11aa60f9ef6335aed343e189d26e4a673"
+dependencies = [
+ "iced_graphics",
+ "iced_runtime",
+]
+
+[[package]]
+name = "iced_renderer"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "250cc0802408e8c077986ec56c7d07c65f423ee658a4b9fd795a1f2aae5dac05"
 dependencies = [
  "iced_graphics",
  "iced_tiny_skia",
  "log",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "iced_runtime"
-version = "0.13.2"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348b5b2c61c934d88ca3b0ed1ed913291e923d086a66fa288ce9669da9ef62b5"
+checksum = "d1889b819ce4c06674183242e336c8d49465665441396914dc07cc86f44fa8d4"
 dependencies = [
  "bytes",
  "iced_core",
  "iced_futures",
  "raw-window-handle",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "iced_tiny_skia"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c625d368284fcc43b0b36b176f76eff1abebe7959dd58bd8ce6897d641962a50"
+checksum = "fe0acf8b75a3bc914aff5f2329fdffc1b36eeaea29dda0e4bd232f1c62e9cc3d"
 dependencies = [
  "bytemuck",
  "cosmic-text",
+ "iced_debug",
  "iced_graphics",
  "kurbo",
  "log",
@@ -2511,35 +2513,32 @@ dependencies = [
 
 [[package]]
 name = "iced_widget"
-version = "0.13.4"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81429e1b950b0e4bca65be4c4278fea6678ea782030a411778f26fa9f8983e1d"
+checksum = "b1596afa0d3109c2618e8bc12bae6c11d3064df8f95c42dfce570397dbe957ab"
 dependencies = [
  "iced_renderer",
- "iced_runtime",
+ "log",
  "num-traits",
- "once_cell",
  "rustc-hash 2.1.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "iced_winit"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f44cd4e1c594b6334f409282937bf972ba14d31fedf03c23aa595d982a2fda28"
+checksum = "8b7dbedc47562d1de3b9707d939f678b88c382004b7ab5a18f7a7dd723162d75"
 dependencies = [
- "iced_futures",
- "iced_graphics",
- "iced_runtime",
+ "iced_debug",
+ "iced_program",
  "log",
  "rustc-hash 2.1.2",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tracing",
  "wasm-bindgen-futures",
  "web-sys",
- "winapi",
  "window_clipboard",
  "winit",
 ]
@@ -2677,7 +2676,7 @@ dependencies = [
  "byteorder-lite",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
 ]
 
 [[package]]
@@ -2720,15 +2719,6 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -2987,16 +2977,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lilt"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67562e5eff6b20553fa9be1c503356768420994e28f67e3eafe6f41910e57ad"
+dependencies = [
+ "web-time",
+]
+
+[[package]]
+name = "linebender_resource_handle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "linux-raw-sys"
@@ -3670,7 +3669,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
 dependencies = [
- "ttf-parser 0.25.1",
+ "ttf-parser",
 ]
 
 [[package]]
@@ -3722,45 +3721,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "palette"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
-dependencies = [
- "approx",
- "fast-srgb8",
- "palette_derive",
- "phf",
-]
-
-[[package]]
-name = "palette_derive"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
-dependencies = [
- "by_address",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
 
 [[package]]
 name = "parking_lot"
@@ -3769,21 +3733,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -3832,48 +3782,6 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3951,19 +3859,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "png"
-version = "0.17.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
-]
 
 [[package]]
 name = "png"
@@ -4313,21 +4208,23 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.22.7"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69aacb76b5c29acfb7f90155d39759a29496aebb49395830e928a9703d2eec2f"
+checksum = "6717cf23b488adf64b9d711329542ba34de147df262370221940dfabc2c91358"
 dependencies = [
  "bytemuck",
- "font-types",
+ "core_maths",
+ "font-types 0.10.1",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.16"
+name = "read-fonts"
+version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
 dependencies = [
- "bitflags 1.3.2",
+ "bytemuck",
+ "font-types 0.11.3",
 ]
 
 [[package]]
@@ -4912,23 +4809,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "rustybuzz"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb9cf8877777222e4a3bc7eb247e398b56baba500c38c1c46842431adc8b55c"
-dependencies = [
- "bitflags 2.11.0",
- "bytemuck",
- "libm",
- "smallvec",
- "ttf-parser 0.21.1",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5210,12 +5090,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
-name = "siphasher"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
-
-[[package]]
 name = "sized-chunks"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5227,12 +5101,22 @@ dependencies = [
 
 [[package]]
 name = "skrifa"
-version = "0.22.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1c44ad1f6c5bdd4eefed8326711b7dbda9ea45dfd36068c427d332aa382cbe"
+checksum = "8c31071dedf532758ecf3fed987cdb4bd9509f900e026ab684b4ecb81ea49841"
 dependencies = [
  "bytemuck",
- "read-fonts",
+ "read-fonts 0.35.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -5349,7 +5233,6 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "as-raw-xcb-connection",
  "bytemuck",
- "drm",
  "fastrand",
  "js-sys",
  "memmap2",
@@ -5484,11 +5367,11 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "swash"
-version = "0.1.19"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd59f3f359ddd2c95af4758c18270eddd9c730dde98598023cdabff472c2ca2"
+checksum = "0811b01ca2c4e8718760713911feaf4675c24f94e50530a015ec646cfb622f7c"
 dependencies = [
- "skrifa",
+ "skrifa 0.42.1",
  "yazi",
  "zeno",
 ]
@@ -5644,7 +5527,6 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5661,12 +5543,12 @@ dependencies = [
 
 [[package]]
 name = "tiny-xlib"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0324504befd01cab6e0c994f34b2ffa257849ee019d3fb3b64fb2c858887d89e"
+checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
 dependencies = [
  "as-raw-xcb-connection",
- "ctor-lite",
+ "ctor",
  "libloading",
  "pkg-config",
  "tracing",
@@ -5998,21 +5880,12 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
-
-[[package]]
-name = "ttf-parser"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
-
-[[package]]
-name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "typenum"
@@ -6038,18 +5911,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cb788ffebc92c5948d0e997106233eeb1d8b9512f93f41651f52b6c5f5af86"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df77b101bcc4ea3d78dafc5ad7e4f58ceffe0b2b16bf446aeb50b6cb4157656"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6060,12 +5921,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -6395,21 +6250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6714,6 +6554,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtimer"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c598d6b99ea013e35844697fc4670d08339d5cda15588f193c6beedd12f644b"
+dependencies = [
+ "futures",
+ "js-sys",
+ "parking_lot",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "wast"
 version = "35.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6794,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-protocols"
-version = "0.32.12"
+version = "0.32.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
 dependencies = [
  "bitflags 2.11.0",
  "wayland-backend",
@@ -7016,16 +6870,16 @@ dependencies = [
 
 [[package]]
 name = "window_clipboard"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d692d46038c433f9daee7ad8757e002a4248c20b0a3fbc991d99521d3bcb6d"
+checksum = "d5654226305eaf2dde8853fb482861d28e5dcecbbd40cb88e8393d94bb80d733"
 dependencies = [
  "clipboard-win",
  "clipboard_macos",
  "clipboard_wayland",
  "clipboard_x11",
  "raw-window-handle",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7592,9 +7446,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yazi"
-version = "0.1.6"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94451ac9513335b5e23d7a8a2b61a7102398b8cca5160829d313e84c9d98be1"
+checksum = "e01738255b5a16e78bbb83e7fbba0a1e7dd506905cfc53f4622d89015a03fbb5"
 
 [[package]]
 name = "yoke"
@@ -7683,9 +7537,9 @@ dependencies = [
 
 [[package]]
 name = "zeno"
-version = "0.2.3"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd15f8e0dbb966fd9245e7498c7e9e5055d9e5c8b676b95bd67091cd11a1e697"
+checksum = "6df3dc4292935e51816d896edcd52aa30bc297907c26167fec31e2b0c6a32524"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.22", features = ["env-filter", "fmt"] }
 async-trait = "0.1.89"
 zeroize = "1.8.2"
-iced = { version = "0.13.1", default-features = false, features = ["tiny-skia", "tokio"] }
+iced = { version = "0.14.0", default-features = false, features = ["tiny-skia", "tokio", "x11", "wayland", "advanced"] }
 tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread", "time", "sync", "signal", "process"] }
 wait-timeout = "0.2"
 landlock = "0.4.4"

--- a/docs/docs/pam.md
+++ b/docs/docs/pam.md
@@ -1,10 +1,15 @@
 # PAM Auto-Unlock
 
 rosec ships a native PAM module (`pam_rosec.so`) that captures your login
-password during the `auth` phase, then passes it to `rosec-pam-unlock` during
-the `session` phase (when the D-Bus session bus is available). This means
-your providers unlock automatically at both **initial login** and
-**screen unlock** — just like gnome-keyring does.
+password during the `auth` phase and passes it to `rosec-pam-unlock` during
+the `session` phase. This unlocks your providers automatically at both
+**initial login** and **screen unlock**.
+
+If the session D-Bus is not yet available when the helper runs (e.g. very
+early in the login sequence), rosecd automatically falls back to a private
+embedded bus at `$XDG_RUNTIME_DIR/rosec/bus`. The PAM helper knows to check
+that path. Once the session bus becomes available, rosecd migrates to it
+transparently. No extra configuration is needed for this to work.
 
 The module also handles **password changes** (`passwd`): when the `password`
 PAM phase fires, it sends the old and new passwords to the daemon, which
@@ -34,47 +39,59 @@ rosec provider add-password <vault-id> --label pam
 Enter your **login password** when prompted. If it matches your vault master
 password, skip this step.
 
-**3.** Add rosec to your PAM config. A drop-in snippet is installed at
-`/etc/pam.d/rosec` — include it from whichever PAM service you use.
+**3.** Add rosec to the PAM config for your display manager and screen locker.
+A drop-in snippet is installed at `/etc/pam.d/rosec` — include it from
+whichever PAM service files are used for login and screen unlock on your system.
 
-### Login + screen lock (recommended)
+The include needs to appear in the PAM files that are actually executed during
+login and screen unlock. Whether `system-local-login` is in that chain depends
+on your distribution and display manager — check which files your DM and screen
+locker include, and add the rosec include to the appropriate ones.
+
+### Common configurations
 
 ```
-# /etc/pam.d/system-local-login — add at the end:
+# /etc/pam.d/system-local-login — covers any DM or locker that includes this file:
 auth      include   rosec
 session   include   rosec
 password  include   rosec
 ```
 
-This covers GDM, SDDM, console login, and screen lockers that include the
-`login` chain (hyprlock, swaylock, etc.). Do **not** add rosec to
-`/etc/pam.d/system-login` — that file is also used by SSH and other remote
-services where there is no D-Bus session bus.
+Do **not** add rosec to `/etc/pam.d/system-login` — that file is also used by
+SSH and other remote services where there is no D-Bus session bus.
 
-### Screen locker only
+If your display manager uses a dedicated PAM config that does not include
+`system-local-login`, add the rosec include there directly:
 
-Most screen lockers include `system-local-login` under the hood, so the above
-is usually sufficient. If yours doesn't, add rosec directly:
-
-```
-# /etc/pam.d/<locker> — add after the existing auth line:
-auth     include   rosec
-session  include   rosec
-```
-
-| Screen locker | PAM config |
+| Display manager / locker | PAM config |
 |---|---|
+| greetd | `/etc/pam.d/greetd` |
+| GDM | `/etc/pam.d/gdm-password` |
+| SDDM | `/etc/pam.d/sddm` |
 | hyprlock | `/etc/pam.d/hyprlock` |
 | swaylock | `/etc/pam.d/swaylock` |
 | i3lock | `/etc/pam.d/i3lock` |
-| GDM | `/etc/pam.d/gdm-password` |
-| SDDM | `/etc/pam.d/sddm` |
+
+For example, on a greetd + hyprlock setup where greetd does not include
+`system-local-login`:
+
+```
+# /etc/pam.d/greetd — add at the end:
+auth      include   rosec
+session   include   rosec
+password  include   rosec
+
+# /etc/pam.d/hyprlock — add at the end:
+auth      include   rosec
+session   include   rosec
+```
 
 ### Fallback: pam_exec (no native module)
 
 If you prefer not to install `pam_rosec.so`, the helper works standalone
-via `pam_exec`. This only works for **screen unlock** (not initial login,
-because the session bus doesn't exist yet during the `auth` phase):
+via `pam_exec`. This only works for **screen unlock** (not initial login),
+because `pam_exec expose_authtok` runs during the `auth` phase only — there
+is no stash-and-replay for the `session` phase:
 
 ```
 # /etc/pam.d/hyprlock — after auth:

--- a/rosec-prompt/Cargo.toml
+++ b/rosec-prompt/Cargo.toml
@@ -8,7 +8,7 @@ repository = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-cosmic-text = "0.12.1"
+cosmic-text = "0.15"
 futures-util = { workspace = true }
 iced = { workspace = true }
 libc = { workspace = true }

--- a/rosec-prompt/src/gui/prompt.rs
+++ b/rosec-prompt/src/gui/prompt.rs
@@ -22,7 +22,7 @@ pub(super) enum Message {
     FieldChanged(usize, String),
     Confirm,
     Cancel,
-    KeyPressed(iced::keyboard::Key),
+    KeyPressed(iced::keyboard::Key, iced::keyboard::Modifiers),
 }
 
 #[derive(Debug)]
@@ -89,8 +89,11 @@ pub(super) fn run(request: PromptRequest) -> Result<()> {
         // focused text_input would consume. `on_key_press` only receives
         // `Status::Ignored`, so the first Esc gets swallowed.
         iced::event::listen_with(|event, _status, _id| {
-            if let iced::Event::Keyboard(iced::keyboard::Event::KeyPressed { key, .. }) = event {
-                Some(Message::KeyPressed(key))
+            if let iced::Event::Keyboard(iced::keyboard::Event::KeyPressed {
+                key, modifiers, ..
+            }) = event
+            {
+                Some(Message::KeyPressed(key, modifiers))
             } else {
                 None
             }
@@ -238,23 +241,34 @@ fn confirm_and_exit(state: &GuiApp) -> ! {
     std::process::exit(0);
 }
 
-fn update(state: &mut GuiApp, message: Message) {
+fn update(state: &mut GuiApp, message: Message) -> iced::Task<Message> {
     match message {
         Message::FieldChanged(idx, value) => {
             if let Some(f) = state.fields.get_mut(idx) {
                 // Old `Zeroizing<String>` drops here → scrubbed.
                 f.value = Zeroizing::new(value);
             }
+            iced::Task::none()
         }
         Message::Confirm => confirm_and_exit(state),
         Message::Cancel => std::process::exit(1),
-        Message::KeyPressed(key) => {
+        Message::KeyPressed(key, modifiers) => {
             use iced::keyboard::Key;
             use iced::keyboard::key::Named;
             match key {
                 Key::Named(Named::Enter) => confirm_and_exit(state),
                 Key::Named(Named::Escape) => std::process::exit(1),
-                _ => {}
+                // iced 0.14 no longer traverses focus on Tab automatically, so
+                // dispatch the focus operation ourselves (Shift+Tab = previous).
+                Key::Named(Named::Tab) => {
+                    use iced::advanced::widget::{operate, operation};
+                    if modifiers.shift() {
+                        operate(operation::focusable::focus_previous())
+                    } else {
+                        operate(operation::focusable::focus_next())
+                    }
+                }
+                _ => iced::Task::none(),
             }
         }
     }

--- a/rosec-prompt/src/gui/prompt.rs
+++ b/rosec-prompt/src/gui/prompt.rs
@@ -4,7 +4,6 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use anyhow::Result;
-use iced::widget::text_input;
 use zeroize::Zeroizing;
 
 use crate::helpers::{
@@ -15,7 +14,8 @@ use crate::output::emit_secret_json;
 use crate::request::{FieldKind, FieldSpec, PromptRequest, ThemeConfig};
 
 /// Stable ID for the first text input so we can auto-focus it on startup.
-static FIRST_FIELD_ID: LazyLock<text_input::Id> = LazyLock::new(text_input::Id::unique);
+static FIRST_FIELD_ID: LazyLock<iced::advanced::widget::Id> =
+    LazyLock::new(iced::advanced::widget::Id::unique);
 
 #[derive(Debug, Clone)]
 pub(super) enum Message {
@@ -63,41 +63,51 @@ pub(super) fn run(request: PromptRequest) -> Result<()> {
     let fields = request.effective_fields();
     let height = derive_window_height(&request, &fields);
 
-    application("rosec prompt", update, view)
-        .subscription(|_state| {
-            // `event::listen_with` sees all keyboard events, including those a
-            // focused text_input would consume. `on_key_press` only receives
-            // `Status::Ignored`, so the first Esc gets swallowed.
-            iced::event::listen_with(|event, _status, _id| {
-                if let iced::Event::Keyboard(iced::keyboard::Event::KeyPressed { key, .. }) = event
-                {
-                    Some(Message::KeyPressed(key))
-                } else {
-                    None
-                }
-            })
-        })
-        .window(iced::window::Settings {
-            size: iced::Size::new(420.0, height),
-            resizable: false,
-            decorations: false,
-            transparent: true,
-            platform_specific: PlatformSpecific {
-                application_id: "rosec.prompt".to_string(),
-                override_redirect: false,
-            },
-            ..Default::default()
-        })
-        .run_with(|| {
+    // iced 0.14: the boot function is the first arg to `application()` and must
+    // be `Fn` (callable by reference), so it clones the captured request/fields
+    // rather than consuming them. Title moved to `.title()`; `.run_with()` →
+    // `.run()`.
+    application(
+        move || {
             let has_fields = !fields.is_empty();
-            let state = GuiApp::from_request(request, fields);
+            let state = GuiApp::from_request(request.clone(), fields.clone());
             let task = if has_fields {
-                iced::widget::text_input::focus(FIRST_FIELD_ID.clone())
+                iced::advanced::widget::operate(
+                    iced::advanced::widget::operation::focusable::focus(FIRST_FIELD_ID.clone()),
+                )
             } else {
                 iced::Task::none()
             };
             (state, task)
-        })?;
+        },
+        update,
+        view,
+    )
+    .title("rosec prompt")
+    .subscription(|_state| {
+        // `event::listen_with` sees all keyboard events, including those a
+        // focused text_input would consume. `on_key_press` only receives
+        // `Status::Ignored`, so the first Esc gets swallowed.
+        iced::event::listen_with(|event, _status, _id| {
+            if let iced::Event::Keyboard(iced::keyboard::Event::KeyPressed { key, .. }) = event {
+                Some(Message::KeyPressed(key))
+            } else {
+                None
+            }
+        })
+    })
+    .window(iced::window::Settings {
+        size: iced::Size::new(420.0, height),
+        resizable: false,
+        decorations: false,
+        transparent: true,
+        platform_specific: PlatformSpecific {
+            application_id: "rosec.prompt".to_string(),
+            override_redirect: false,
+        },
+        ..Default::default()
+    })
+    .run()?;
     Ok(())
 }
 
@@ -254,7 +264,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
     use iced::widget::{button, column, container, row, text, text_input};
     use iced::{Alignment, Background, Element, Length};
 
-    let font_size = state.theme.font_size as u16;
+    let font_size = state.theme.font_size;
 
     let title_widget: Element<'_, Message> = {
         let bold_font = iced::Font {
@@ -262,7 +272,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
             ..state.font
         };
         let t = text(&state.title)
-            .size(font_size + 1)
+            .size(font_size + 1.0)
             .color(state.fg)
             .font(bold_font);
         if state.hint.trim().is_empty() {
@@ -270,7 +280,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
         } else {
             iced::widget::tooltip(
                 t,
-                container(iced::widget::rich_text(parse_styled_spans(
+                container(iced::widget::rich_text(parse_styled_spans::<Message>(
                     &state.hint,
                     font_size,
                     state.label_color,
@@ -287,6 +297,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
                     },
                     text_color: None,
                     shadow: iced::Shadow::default(),
+                    snap: false,
                 }),
                 iced::widget::tooltip::Position::Bottom,
             )
@@ -305,7 +316,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
             } else {
                 &f.spec.label
             })
-            .size(font_size - 1)
+            .size(font_size - 1.0)
             .color(state.label_color)
             .font(state.font);
             let mut inp = text_input(f.spec.placeholder.as_str(), f.value.as_str())
@@ -326,7 +337,10 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
                     move |_, status| iced::widget::text_input::Style {
                         background: Background::Color(ibg),
                         border: iced::Border {
-                            color: if status == iced::widget::text_input::Status::Focused {
+                            color: if matches!(
+                                status,
+                                iced::widget::text_input::Status::Focused { .. }
+                            ) {
                                 accent
                             } else {
                                 border
@@ -383,9 +397,9 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
     let mut items: Vec<Element<'_, Message>> = vec![title_widget];
 
     if !state.info.trim().is_empty() {
-        let spans = parse_styled_spans(
+        let spans = parse_styled_spans::<Message>(
             &state.info,
-            font_size - 1,
+            font_size - 1.0,
             state.label_color,
             state.fg,
             state.font,
@@ -395,7 +409,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
     }
 
     if !state.message.is_empty() {
-        let spans = parse_styled_spans(
+        let spans = parse_styled_spans::<Message>(
             &state.message,
             font_size,
             state.label_color,
@@ -428,6 +442,7 @@ fn view(state: &GuiApp) -> iced::Element<'_, Message> {
             },
             text_color: None,
             shadow: iced::Shadow::default(),
+            snap: false,
         })
         .into()
 }

--- a/rosec-prompt/src/gui/qr.rs
+++ b/rosec-prompt/src/gui/qr.rs
@@ -46,23 +46,30 @@ pub(super) fn run(request: PromptRequest) -> Result<()> {
     let initial_status = "Position the QR code on your screen, then click Scan";
     let initial_size = derive_window_size(&request.title, initial_status, &request.theme);
 
-    application("rosec prompt", update, view)
-        .subscription(subscription)
-        .window(iced::window::Settings {
-            size: initial_size,
-            resizable: false,
-            decorations: false,
-            transparent: true,
-            platform_specific: PlatformSpecific {
-                application_id: "rosec.prompt".to_string(),
-                override_redirect: false,
-            },
-            ..Default::default()
-        })
-        .run_with(move || {
+    // iced 0.14: boot fn is the first arg to `application()`; title moved to
+    // `.title()`; `.run_with()` → `.run()`.
+    application(
+        move || {
             let state = QrApp::from_request(&request);
             (state, iced::Task::none())
-        })?;
+        },
+        update,
+        view,
+    )
+    .title("rosec prompt")
+    .subscription(subscription)
+    .window(iced::window::Settings {
+        size: initial_size,
+        resizable: false,
+        decorations: false,
+        transparent: true,
+        platform_specific: PlatformSpecific {
+            application_id: "rosec.prompt".to_string(),
+            override_redirect: false,
+        },
+        ..Default::default()
+    })
+    .run()?;
     Ok(())
 }
 
@@ -238,7 +245,7 @@ fn update(state: &mut QrApp, message: QrMessage) -> iced::Task<QrMessage> {
         QrMessage::Scan => {
             state.scanning = true;
             state.status = "Scanning...".to_string();
-            iced::window::get_oldest().and_then(|id| {
+            iced::window::oldest().and_then(|id| {
                 iced::window::minimize(id, true).chain(iced::Task::done(QrMessage::WindowHidden))
             })
         }
@@ -279,7 +286,7 @@ fn update(state: &mut QrApp, message: QrMessage) -> iced::Task<QrMessage> {
             // Re-measure: error text typically wraps and would overflow the
             // initial "Position the QR..." height.
             let new_size = derive_window_size(&state.title, &state.status, &state.theme);
-            iced::window::get_oldest().and_then(move |id| {
+            iced::window::oldest().and_then(move |id| {
                 iced::window::resize(id, new_size).chain(iced::window::minimize(id, false))
             })
         }
@@ -309,7 +316,7 @@ fn view(state: &QrApp) -> iced::Element<'_, QrMessage> {
     use iced::widget::{button, column, container, row, text};
     use iced::{Alignment, Background, Element, Length};
 
-    let font_size = state.theme.font_size as u16;
+    let font_size = state.theme.font_size;
 
     let bold_font = iced::Font {
         weight: iced::font::Weight::Bold,
@@ -317,7 +324,7 @@ fn view(state: &QrApp) -> iced::Element<'_, QrMessage> {
     };
 
     let title_widget: Element<'_, QrMessage> = text(&state.title)
-        .size(font_size + 1)
+        .size(font_size + 1.0)
         .color(state.fg)
         .font(bold_font)
         .into();
@@ -384,6 +391,7 @@ fn view(state: &QrApp) -> iced::Element<'_, QrMessage> {
             },
             text_color: None,
             shadow: iced::Shadow::default(),
+            snap: false,
         })
         .into()
 }

--- a/rosec-prompt/src/gui/totp.rs
+++ b/rosec-prompt/src/gui/totp.rs
@@ -50,26 +50,33 @@ pub(super) fn run(request: PromptRequest) -> Result<()> {
         .ok_or_else(|| anyhow::anyhow!("totp_display missing"))?;
     let code = totp.code.clone();
 
-    application("rosec prompt", update, view)
-        .subscription(subscription)
-        .window(iced::window::Settings {
-            size: iced::Size::new(380.0, 190.0),
-            resizable: false,
-            decorations: false,
-            transparent: true,
-            platform_specific: PlatformSpecific {
-                application_id: "rosec.prompt".to_string(),
-                override_redirect: false,
-            },
-            ..Default::default()
-        })
-        .run_with(move || {
+    // iced 0.14: boot fn is the first arg to `application()`; title moved to
+    // `.title()`; `.run_with()` → `.run()`.
+    application(
+        move || {
             let state = TotpApp::from_request(&request);
             if state.confirm_label.is_none() {
                 clipboard_write(&code);
             }
             (state, iced::Task::none())
-        })?;
+        },
+        update,
+        view,
+    )
+    .title("rosec prompt")
+    .subscription(subscription)
+    .window(iced::window::Settings {
+        size: iced::Size::new(380.0, 190.0),
+        resizable: false,
+        decorations: false,
+        transparent: true,
+        platform_specific: PlatformSpecific {
+            application_id: "rosec.prompt".to_string(),
+            override_redirect: false,
+        },
+        ..Default::default()
+    })
+    .run()?;
     Ok(())
 }
 
@@ -253,7 +260,7 @@ fn view(state: &TotpApp) -> iced::Element<'_, TotpMessage> {
     use iced::widget::{button, column, container, row, text};
     use iced::{Alignment, Background, Element, Length};
 
-    let font_size = state.theme.font_size as u16;
+    let font_size = state.theme.font_size;
 
     let bold_font = iced::Font {
         weight: iced::font::Weight::Bold,
@@ -261,7 +268,7 @@ fn view(state: &TotpApp) -> iced::Element<'_, TotpMessage> {
     };
 
     let title_widget: Element<'_, TotpMessage> = text(&state.title)
-        .size(font_size + 1)
+        .size(font_size + 1.0)
         .color(state.fg)
         .font(bold_font)
         .into();
@@ -361,6 +368,7 @@ fn view(state: &TotpApp) -> iced::Element<'_, TotpMessage> {
             },
             text_color: None,
             shadow: iced::Shadow::default(),
+            snap: false,
         })
         .into()
 }

--- a/rosec-prompt/src/gui/totp.rs
+++ b/rosec-prompt/src/gui/totp.rs
@@ -44,20 +44,18 @@ pub(super) fn run(request: PromptRequest) -> Result<()> {
     use iced::application;
     use iced::window::settings::PlatformSpecific;
 
-    let totp = request
+    // Fail fast on a malformed request (from_request also expects totp_display).
+    request
         .totp_display
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("totp_display missing"))?;
-    let code = totp.code.clone();
 
     // iced 0.14: boot fn is the first arg to `application()`; title moved to
-    // `.title()`; `.run_with()` → `.run()`.
+    // `.title()`; `.run_with()` → `.run()`. The TOTP code is copied only on an
+    // explicit Copy-button press — never automatically at open.
     application(
         move || {
             let state = TotpApp::from_request(&request);
-            if state.confirm_label.is_none() {
-                clipboard_write(&code);
-            }
             (state, iced::Task::none())
         },
         update,
@@ -142,59 +140,84 @@ impl TotpApp {
     }
 }
 
-/// Write the TOTP code to the clipboard with auto-clear semantics.
+/// Write the TOTP code to the clipboard via `wl-copy` (Wayland) or `xclip`
+/// (X11). Both fork a background process that owns the selection and keeps
+/// serving it after we exit — iced's own clipboard can't, since it serves the
+/// selection through the (about-to-close) window.
 ///
-/// `wl-copy --paste-once` is a one-shot: the clipboard is consumed by the
-/// first paste, after which the clipboard reverts to whatever was there
-/// before. iced's clipboard API needs a live window surface, which is
-/// impractical for a prompt that exits immediately after copy — hence the
-/// subprocess.
+/// The caller must keep the process alive briefly after this returns (see the
+/// settle in the `CopyToClipboard` handler): the copy tool's daemon needs a
+/// moment to take ownership of the selection, and exiting instantly races that
+/// hand-off and leaves the clipboard empty.
 ///
-/// `xclip` has no equivalent flag, so we fork a detached helper that
-/// overwrites the selection with an empty string after `clear_after`.
+/// Note: `--paste-once` (auto-clear after one paste) is intentionally *not*
+/// used — with a clipboard manager it's consumed immediately, and it doesn't
+/// survive the copy-then-exit hand-off. TOTP codes are short-lived anyway.
 fn clipboard_write(text: &str) {
     use std::process::{Command, Stdio};
 
-    // Wayland: --paste-once clears the clipboard after the first paste.
-    if let Ok(mut child) = Command::new("wl-copy")
-        .arg("--paste-once")
-        .stdin(Stdio::piped())
+    // wl-copy (and xclip) create a private temp dir via mkdtemp to serve the
+    // selection. Under the Landlock sandbox /tmp isn't writable, so point
+    // TMPDIR at XDG_RUNTIME_DIR (which the GUI ruleset already allows) rather
+    // than widening the sandbox. /dev/null (for the Stdio redirections) is
+    // likewise granted in sandbox.rs.
+    let tmpdir = std::env::var_os("XDG_RUNTIME_DIR");
+
+    let mut wl = Command::new("wl-copy");
+    wl.stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        if let Some(mut stdin) = child.stdin.take() {
-            use std::io::Write;
-            let _ = stdin.write_all(text.as_bytes());
+        .stderr(Stdio::null());
+    if let Some(t) = &tmpdir {
+        wl.env("TMPDIR", t);
+    }
+    match wl.spawn() {
+        Ok(mut child) => {
+            if let Some(mut stdin) = child.stdin.take() {
+                use std::io::Write;
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            let _ = child.wait();
+            return;
         }
-        let _ = child.wait();
-        return;
+        Err(e) => {
+            tracing::debug!("wl-copy unavailable ({e}), falling back to xclip");
+        }
     }
 
     // X11 fallback: xclip has no auto-clear flag. Stamp the selection now,
     // then schedule a delayed clear via a detached subprocess. 30 s matches
     // the typical TOTP step.
-    if let Ok(mut child) = Command::new("xclip")
-        .args(["-selection", "clipboard"])
+    let mut xc = Command::new("xclip");
+    xc.args(["-selection", "clipboard"])
         .stdin(Stdio::piped())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-    {
-        if let Some(mut stdin) = child.stdin.take() {
-            use std::io::Write;
-            let _ = stdin.write_all(text.as_bytes());
-        }
-        let _ = child.wait();
+        .stderr(Stdio::null());
+    if let Some(t) = &tmpdir {
+        xc.env("TMPDIR", t);
+    }
+    match xc.spawn() {
+        Ok(mut child) => {
+            if let Some(mut stdin) = child.stdin.take() {
+                use std::io::Write;
+                let _ = stdin.write_all(text.as_bytes());
+            }
+            let _ = child.wait();
 
-        // Detached `sh -c "sleep 30 && xclip -i ..."` — survives our exit.
-        let _ = Command::new("sh")
-            .arg("-c")
-            .arg("sleep 30 && printf '' | xclip -selection clipboard -i 2>/dev/null")
-            .stdin(Stdio::null())
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn();
+            // Detached `sh -c "sleep 30 && xclip -i ..."` — survives our exit.
+            let _ = Command::new("sh")
+                .arg("-c")
+                .arg("sleep 30 && printf '' | xclip -selection clipboard -i 2>/dev/null")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn();
+        }
+        Err(e) => {
+            tracing::warn!(
+                "clipboard copy failed: could not run wl-copy or xclip ({e}); \
+                 the TOTP code was not copied to the clipboard"
+            );
+        }
     }
 }
 
@@ -222,6 +245,11 @@ fn update(state: &mut TotpApp, message: TotpMessage) -> iced::Task<TotpMessage> 
         }
         TotpMessage::CopyToClipboard => {
             clipboard_write(&state.code);
+            // Let wl-copy/xclip's background daemon take ownership of the
+            // selection before we exit; a bare exit here races the hand-off
+            // and leaves the clipboard empty. 400 ms is imperceptible for a
+            // click-to-close action but reliably wins the race.
+            std::thread::sleep(std::time::Duration::from_millis(400));
             emit_empty_and_exit();
         }
         TotpMessage::AutoDismiss => {

--- a/rosec-prompt/src/helpers.rs
+++ b/rosec-prompt/src/helpers.rs
@@ -68,12 +68,18 @@ impl<'a> TextMeasurer<'a> {
         let metrics = cosmic_text::Metrics::new(font_size, lh);
         let mut buffer = cosmic_text::Buffer::new(&mut self.font_system, metrics);
         buffer.set_size(&mut self.font_system, Some(self.content_w), None);
-        let attrs = cosmic_text::Attrs::new().family(self.family).weight(weight);
+        // cosmic-text 0.15 dropped the `.family()`/`.weight()` builders; set the
+        // (public) fields directly, and `set_text` now borrows the attrs and
+        // takes a trailing alignment argument.
+        let mut attrs = cosmic_text::Attrs::new();
+        attrs.family = self.family;
+        attrs.weight = weight;
         buffer.set_text(
             &mut self.font_system,
             text,
-            attrs,
+            &attrs,
             cosmic_text::Shaping::Advanced,
+            None,
         );
         buffer.shape_until_scroll(&mut self.font_system, false);
 
@@ -106,7 +112,49 @@ pub(crate) fn cosmic_font_family(name: &str) -> cosmic_text::Family<'_> {
     cosmic_text::Family::Name(name)
 }
 pub(crate) fn parse_color(value: &str, fallback: iced::Color) -> iced::Color {
-    iced::Color::parse(value.trim()).unwrap_or(fallback)
+    parse_hex_color(value.trim()).unwrap_or(fallback)
+}
+
+/// Parse a `#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa` hex string into a color.
+///
+/// Replaces iced 0.13's `Color::parse`, which was removed in 0.14. Matches the
+/// prior hex-only behaviour (the `#` prefix is optional; no named colors).
+fn parse_hex_color(input: &str) -> Option<iced::Color> {
+    let hex = input.strip_prefix('#').unwrap_or(input);
+    // Single hex digit expanded to a byte (0xF -> 0xFF), normalized to 0.0..=1.0.
+    fn nib(c: char) -> Option<f32> {
+        c.to_digit(16).map(|v| (v * 17) as f32 / 255.0)
+    }
+    // Two hex chars -> byte, normalized to 0.0..=1.0.
+    fn byte(s: &str) -> Option<f32> {
+        u8::from_str_radix(s, 16).ok().map(|v| v as f32 / 255.0)
+    }
+    match hex.len() {
+        3 | 4 => {
+            let c: Vec<char> = hex.chars().collect();
+            let a = if hex.len() == 4 { nib(c[3])? } else { 1.0 };
+            Some(iced::Color::from_rgba(
+                nib(c[0])?,
+                nib(c[1])?,
+                nib(c[2])?,
+                a,
+            ))
+        }
+        6 | 8 => {
+            let a = if hex.len() == 8 {
+                byte(&hex[6..8])?
+            } else {
+                1.0
+            };
+            Some(iced::Color::from_rgba(
+                byte(&hex[0..2])?,
+                byte(&hex[2..4])?,
+                byte(&hex[4..6])?,
+                a,
+            ))
+        }
+        _ => None,
+    }
 }
 
 pub(crate) fn font_from_string(name: &str) -> iced::Font {
@@ -158,6 +206,7 @@ pub(crate) fn button_style(
             radius: 6.0.into(),
         },
         shadow: iced::Shadow::default(),
+        snap: false,
     };
     match status {
         iced::widget::button::Status::Hovered => iced::widget::button::Style {
@@ -175,7 +224,7 @@ pub(crate) fn button_style(
 /// Render a TOTP code as individual digit boxes (pin-entry style).
 pub(crate) fn pin_box_row<'a, M: 'a>(
     code: &str,
-    font_size: u16,
+    font_size: f32,
     digit_color: iced::Color,
     box_bg: iced::Color,
     box_border: iced::Color,
@@ -188,8 +237,8 @@ pub(crate) fn pin_box_row<'a, M: 'a>(
         weight: iced::font::Weight::Bold,
         ..iced::Font::default()
     };
-    let digit_size = font_size + 8;
-    let box_size = (digit_size as f32 * 1.8).ceil();
+    let digit_size = font_size + 8.0;
+    let box_size = (digit_size * 1.8).ceil();
 
     let digit_boxes: Vec<iced::Element<'_, M>> = code
         .chars()
@@ -213,6 +262,7 @@ pub(crate) fn pin_box_row<'a, M: 'a>(
                     },
                     text_color: None,
                     shadow: iced::Shadow::default(),
+                    snap: false,
                 })
                 .into()
         })
@@ -234,7 +284,7 @@ pub(crate) fn pin_box_row<'a, M: 'a>(
 /// and identifiers like `OAUTH_CLIENT_ID` don't get accidentally italicised.
 pub(crate) fn parse_styled_spans<'a, M: 'a>(
     input: &str,
-    size: u16,
+    size: f32,
     normal_color: iced::Color,
     emphasis_color: iced::Color,
     base_font: iced::Font,

--- a/rosec-prompt/src/sandbox.rs
+++ b/rosec-prompt/src/sandbox.rs
@@ -80,6 +80,10 @@ fn add_gui_paths(paths: &mut Vec<PathRule>) {
     }
     paths.push(PathRule::rw("/tmp/.X11-unix"));
 
+    // /dev/null for subprocess stdio redirection (clipboard_write spawns
+    // wl-copy/xclip with Stdio::null()).
+    paths.push(PathRule::rw("/dev/null"));
+
     // GPU device nodes for the iced/wgpu render path.
     paths.push(PathRule::rw("/dev/dri"));
     paths.push(PathRule::ro("/sys/devices"));


### PR DESCRIPTION
Upgrades `rosec-prompt` from **iced 0.13.1 → 0.14.0** and fixes three pre-existing/exposed bugs found while verifying the GUI live on Wayland (niri).

## iced 0.14 migration (d8560de)
- iced 0.13.1 → 0.14.0; **cosmic-text 0.12 → 0.15** on the direct dep too, to keep a single font stack (no fontdb/rustybuzz/swash duplication).
- New features required: `x11` + `wayland` (0.14 made them opt-in — without them `softbuffer` won't compile) and `advanced` (widget operation/Id APIs).
- API migrations: `application(boot, update, view).title(..).run()` (boot fns must be `Fn`, so the prompt clones captured state); `text_input::focus` → `operate(operation::focusable::focus(id))`; `window::get_oldest()` → `oldest()`; `container/button::Style { snap }`; `text_input::Status::Focused { .. }`; text sizes now `f32` (u16→f32 plumbing); `Color::parse` replaced with a local hex parser; rich_text `Link` type pinned; cosmic-text 0.15 attrs rework.

## Fixes
- **Tab focus traversal (8ce894c):** iced 0.14 dropped built-in Tab traversal, so multi-field prompts couldn't Tab between inputs. Now handled in `update` via `focus_next()`/`focus_previous()` (Shift+Tab).
- **`/dev/null` Landlock gap (156210b):** the GUI ruleset never granted `/dev/null`, so *any* subprocess spawned with `Stdio::null()` failed `EACCES` before exec. This silently broke **both** the TOTP clipboard copy (wl-copy) and the **QR scanner** (re-execs itself as `--screenshot-helper`). Granting `/dev/null` repairs both.
- **TOTP clipboard copy (62699aa):** now copies **only on the Copy button** (removed the copy-on-open, which never worked — it ran before the window existed). Fixed wl-copy's `mkdtemp: Permission denied` by pointing `TMPDIR` at `XDG_RUNTIME_DIR` instead of widening the sandbox. Added a 400 ms settle before exit so wl-copy's background daemon can take ownership of the selection (copy-then-exit was racing the hand-off → empty clipboard). Dropped `--paste-once` (consumed immediately by clipboard managers; doesn't survive the hand-off). Clipboard failures are now logged.

## Verification
- CI-equivalent local: `fmt`, `clippy -D warnings`, `cargo test --workspace` (~290 tests), `cargo audit` (workspace + 4 providers), **MSRV 1.91** (workspace + providers), and all 4 WASM provider `wasm32-wasip1` builds — all green.
- **Live GUI (Wayland/niri):** verified prompts (default, single/multi-field, rich text + tooltip, long-wrap, no-text, visible text, custom labels, confirm-mode), the new hex color parser (6/3/8-digit + no-`#`), **Tab/Shift+Tab** between fields, **TOTP copy button** (paste confirmed), and **QR scan** decoding a live `otpauth://` code.

## Notes
- Only remaining untested variant is `totp-confirm` (same render path as the TOTP display, minus the copy) — low risk.
- Dev-only: the QR self-re-exec needs the binary's dir allowed under Landlock; production installs to `/usr/bin` (covered by the existing `/usr` rule), so no repo change — a dev test harness sets `ROSEC_LANDLOCK_RO_PATHS`.