### PR TITLE
feat(packaging): ship rosec-uhid broker as a separate AUR package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,7 @@ jobs:
         run: |
           cargo build --release --locked \
             --bin rosecd --bin rosec --bin rosec-prompt --bin rosec-pam-unlock \
+            --bin rosec-uhid \
             --target ${{ matrix.target }}
 
       - name: Build PAM module (native only)
@@ -214,6 +215,7 @@ jobs:
         run: |
           cross build --release --locked \
             --bin rosecd --bin rosec --bin rosec-prompt --bin rosec-pam-unlock \
+            --bin rosec-uhid \
             --target ${{ matrix.target }}
 
       - name: Package artifacts
@@ -227,6 +229,7 @@ jobs:
           cp "target/${TARGET}/release/rosec"  "${STAGE}/"
           cp "target/${TARGET}/release/rosec-prompt" "${STAGE}/"
           cp "target/${TARGET}/release/rosec-pam-unlock" "${STAGE}/"
+          cp "target/${TARGET}/release/rosec-uhid" "${STAGE}/"
           cp -r contrib "${STAGE}/"
           cp README.md  "${STAGE}/" 2>/dev/null || true
           cp LICENSE     "${STAGE}/" 2>/dev/null || true
@@ -559,6 +562,54 @@ jobs:
           pkgname: rosec-bin
           pkgbuild: ${{ github.workspace }}/PKGBUILD-rendered
           assets: contrib/aur/rosec.install
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          commit_message: "Update to ${{ needs.prepare.outputs.version }}"
+          force_push: true
+
+  # ---------------------------------------------------------------------------
+  # AUR rosec-uhid-bin package (optional FIDO2 broker)
+  #
+  # Separate package: only users who want the WebAuthn/passkey virtual
+  # authenticator install it. It reuses the main release tarball (which carries
+  # the rosec-uhid binary and the contrib/uhid units + modules-load file).
+  # ---------------------------------------------------------------------------
+  aur-publish-uhid:
+    name: Publish rosec-uhid-bin to AUR
+    runs-on: ubuntu-latest
+    needs: [prepare, release]
+    if: needs.prepare.outputs.is_release == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Download x86_64 artifact (for PKGBUILD checksum)
+        uses: actions/download-artifact@v8
+        with:
+          name: rosec-x86_64-unknown-linux-gnu
+          path: artifacts
+
+      - name: Compute checksums for PKGBUILD
+        id: checksums
+        run: |
+          X86_64_SHA=$(awk '{print $1}' artifacts/rosec-*-x86_64-unknown-linux-gnu.tar.gz.sha256)
+          echo "x86_64_sha=${X86_64_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Render PKGBUILD from template
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          sed \
+            -e "s|@VERSION@|${VERSION}|g" \
+            -e "s|@X86_64_SHA256@|${{ steps.checksums.outputs.x86_64_sha }}|g" \
+            contrib/aur/PKGBUILD-uhid-bin > "$GITHUB_WORKSPACE/PKGBUILD-rendered"
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: rosec-uhid-bin
+          pkgbuild: ${{ github.workspace }}/PKGBUILD-rendered
+          assets: contrib/aur/rosec-uhid.install
           commit_username: ${{ secrets.AUR_USERNAME }}
           commit_email: ${{ secrets.AUR_EMAIL }}
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}

--- a/contrib/aur/PKGBUILD
+++ b/contrib/aur/PKGBUILD
@@ -34,6 +34,7 @@ optdepends=(
     'fuse3: SSH key FUSE filesystem at $XDG_RUNTIME_DIR/rosec/ssh'
     'openssh: SSH agent support'
     'libnotify: desktop notifications on lock/unlock'
+    'rosec-uhid-bin: FIDO2/WebAuthn virtual authenticator (serve passkeys to browsers)'
 )
 provides=(
     'org.freedesktop.secrets'

--- a/contrib/aur/PKGBUILD-bin
+++ b/contrib/aur/PKGBUILD-bin
@@ -29,6 +29,7 @@ optdepends+=(
     'rosec-provider-bitwarden-sm-bin: Bitwarden Secrets Manager provider (sync)'
     'rosec-provider-gnome-keyring-bin: GNOME Keyring read-only provider'
     'rosec-provider-keepassxc-file-bin: KeePassXC (.kdbx file) read-only provider (experimental)'
+    'rosec-uhid-bin: FIDO2/WebAuthn virtual authenticator (serve passkeys to browsers)'
 )
 provides=('rosec' 'org.freedesktop.secrets')
 conflicts=('rosec')

--- a/contrib/aur/PKGBUILD-git
+++ b/contrib/aur/PKGBUILD-git
@@ -36,6 +36,7 @@ optdepends=(
     'fuse3: SSH key FUSE filesystem at $XDG_RUNTIME_DIR/rosec/ssh'
     'openssh: SSH agent support'
     'libnotify: desktop notifications on lock/unlock'
+    'rosec-uhid-bin: FIDO2/WebAuthn virtual authenticator (serve passkeys to browsers)'
 )
 provides=(
     'rosec'

--- a/contrib/aur/PKGBUILD-uhid-bin
+++ b/contrib/aur/PKGBUILD-uhid-bin
@@ -1,0 +1,73 @@
+# Maintainer: John Mylchreest <jmylchreest@gmail.com>
+#
+# AUR package: rosec-uhid-bin
+#
+# The privileged, disposable broker for rosec's FIDO2 / WebAuthn virtual
+# authenticator. Install this only if you want rosec to serve passkeys to
+# browsers as a security key.
+#
+# /dev/uhid is root-only (unrestricted uhid access can forge input devices),
+# so a tiny socket-activated system service opens it, creates a device with a
+# hard-coded FIDO usage-page descriptor, chowns the hidraw node to the
+# requesting user, passes the fd back over SCM_RIGHTS, and exits. All CTAP
+# logic then runs unprivileged inside the user's rosecd.
+#
+# The broker is standalone: it does not depend on rosec at runtime (rosecd
+# connects to *it*). rosec lists this package in its optdepends.
+#
+# This reuses the main rosec release tarball, which already carries the
+# rosec-uhid binary and the contrib/uhid units + modules-load file. The
+# release workflow renders this file by substituting @VERSION@ and the
+# @X86_64_SHA256@ / @AARCH64_SHA256@ checksums before committing to the AUR.
+#
+# To build manually, replace the placeholders and run makepkg -si.
+
+pkgname=rosec-uhid-bin
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="Privileged broker for rosec's FIDO2/WebAuthn virtual authenticator (prebuilt)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jmylchreest/rosec"
+license=('MIT')
+optdepends=(
+    'rosec: the Secret Service daemon that drives the virtual authenticator'
+)
+provides=('rosec-uhid')
+conflicts=('rosec-uhid')
+install=rosec-uhid.install
+
+source_x86_64=(
+    "rosec-${pkgver}-x86_64.tar.gz::https://github.com/jmylchreest/rosec/releases/download/v${pkgver}/rosec-${pkgver}-x86_64-unknown-linux-gnu.tar.gz"
+)
+source_aarch64=(
+    "rosec-${pkgver}-aarch64.tar.gz::https://github.com/jmylchreest/rosec/releases/download/v${pkgver}/rosec-${pkgver}-aarch64-unknown-linux-gnu.tar.gz"
+)
+
+sha256sums_x86_64=('@X86_64_SHA256@')
+sha256sums_aarch64=('@AARCH64_SHA256@')
+
+package() {
+    # The tarball unpacks to a directory named after the target triple.
+    local srcdir_inner
+    srcdir_inner=$(find "${srcdir}" -maxdepth 1 -type d -name '*-linux-gnu' | head -1)
+
+    # The privileged broker binary
+    install -Dm755 "${srcdir_inner}/rosec-uhid" \
+        "${pkgdir}/usr/bin/rosec-uhid"
+
+    # Socket-activated system service (not enabled by default — see the
+    # post-install message)
+    install -Dm644 "${srcdir_inner}/contrib/uhid/rosec-uhid.socket" \
+        "${pkgdir}/usr/lib/systemd/system/rosec-uhid.socket"
+    install -Dm644 "${srcdir_inner}/contrib/uhid/rosec-uhid.service" \
+        "${pkgdir}/usr/lib/systemd/system/rosec-uhid.service"
+
+    # Load the uhid module at boot so /dev/uhid exists (the broker's hardened
+    # unit cannot modprobe it itself)
+    install -Dm644 "${srcdir_inner}/contrib/uhid/modules-load.conf" \
+        "${pkgdir}/usr/lib/modules-load.d/rosec-uhid.conf"
+
+    # License
+    install -Dm644 "${srcdir_inner}/LICENSE" \
+        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}

--- a/contrib/aur/rosec-uhid.install
+++ b/contrib/aur/rosec-uhid.install
@@ -1,0 +1,33 @@
+post_install() {
+    echo ""
+    echo "==> rosec-uhid: FIDO2 / WebAuthn virtual authenticator"
+    echo ""
+    echo "  This installed the privileged broker, its systemd units, and a"
+    echo "  modules-load file for uhid. Nothing is enabled yet."
+    echo ""
+    echo "  To let browsers use rosec's passkeys as a security key:"
+    echo ""
+    echo "    1. Enable the broker socket (root):"
+    echo "         sudo systemctl enable --now rosec-uhid.socket"
+    echo ""
+    echo "    2. Turn on the frontend in your rosec config (~/.config/rosec/config.toml):"
+    echo "         [service]"
+    echo "         fido2 = true"
+    echo ""
+    echo "    3. Restart your daemon:"
+    echo "         systemctl --user restart rosecd"
+    echo ""
+    echo "  The uhid module loads at next boot; to use it now without rebooting:"
+    echo "         sudo modprobe uhid"
+    echo ""
+    echo "  This is a per-user, opt-in desktop feature. Each user's device is"
+    echo "  isolated (owned by that user at 0600), so concurrent local users are"
+    echo "  safe; there is no reason to enable it on a headless server."
+    echo ""
+    echo "  See: https://github.com/jmylchreest/rosec/blob/main/docs/docs/fido2-passkeys.md"
+    echo ""
+}
+
+post_upgrade() {
+    post_install
+}

--- a/contrib/uhid/README.md
+++ b/contrib/uhid/README.md
@@ -25,12 +25,20 @@ The rosecd user unit is unsuitable: it runs as the user and cannot open
 
 ## Install
 
+On Arch, prefer the `rosec-uhid-bin` AUR package, which installs all of this.
+By hand:
+
 ```sh
 install -Dm755 rosec-uhid            /usr/bin/rosec-uhid
 install -Dm644 rosec-uhid.socket     /usr/lib/systemd/system/rosec-uhid.socket
 install -Dm644 rosec-uhid.service    /usr/lib/systemd/system/rosec-uhid.service
+install -Dm644 modules-load.conf     /usr/lib/modules-load.d/rosec-uhid.conf
 systemctl enable --now rosec-uhid.socket
 ```
+
+`/dev/uhid` only exists once the `uhid` module is loaded. The `modules-load.d`
+file loads it at boot; the broker cannot load it itself (its unit sets
+`ProtectKernelModules=yes`). To use it immediately: `modprobe uhid`.
 
 ## hidraw ownership
 

--- a/contrib/uhid/modules-load.conf
+++ b/contrib/uhid/modules-load.conf
@@ -1,0 +1,6 @@
+# Load the uhid module at boot so /dev/uhid exists for the rosec-uhid broker.
+#
+# The broker cannot load it on demand: its service unit sets
+# ProtectKernelModules=yes, and /dev/uhid does not exist until the module is
+# loaded. Installed to /usr/lib/modules-load.d/rosec-uhid.conf.
+uhid

--- a/docs/docs/fido2-passkeys.md
+++ b/docs/docs/fido2-passkeys.md
@@ -20,10 +20,11 @@ The feature is **off by default** and aimed at desktop use. Three pieces
 enable it:
 
 1. **The `rosec-uhid` broker** — a small system service (root,
-   socket-activated) that creates the virtual device. See
+   socket-activated) that creates the virtual device. Install the separate
+   `rosec-uhid-bin` package (or build from `contrib/uhid/`); see
    [Installation](installation#fido2).
-2. **The `uhid` kernel module** — loaded automatically once the broker's
-   module-load file is in place.
+2. **The `uhid` kernel module** — loaded at boot by the `modules-load.d` file
+   the broker package ships (or `sudo modprobe uhid` to load it now).
 3. **`fido2 = true`** under `[service]` in your [configuration](configuration),
    after which you restart rosecd.
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -87,15 +87,29 @@ what it does and how to use it.
 It needs one extra system service, the **`rosec-uhid` broker**. `/dev/uhid`
 (the kernel's virtual-HID facility) is root-only, so a tiny privileged broker
 creates the device and hands it to your unprivileged daemon — rosecd itself
-never runs as root. The broker ships with the release under `contrib/uhid/`:
+never runs as root.
+
+On Arch, install the separate package:
 
 ```bash
-# From the contrib/uhid/ directory (packages install these for you)
-sudo install -Dm755 rosec-uhid        /usr/bin/rosec-uhid
-sudo install -Dm644 rosec-uhid.socket /usr/lib/systemd/system/rosec-uhid.socket
-sudo install -Dm644 rosec-uhid.service /usr/lib/systemd/system/rosec-uhid.service
+paru -S rosec-uhid-bin      # or your AUR helper of choice
 sudo systemctl enable --now rosec-uhid.socket
 ```
+
+Or install it by hand from `contrib/uhid/` in the source tree:
+
+```bash
+sudo install -Dm755 rosec-uhid         /usr/bin/rosec-uhid
+sudo install -Dm644 rosec-uhid.socket  /usr/lib/systemd/system/rosec-uhid.socket
+sudo install -Dm644 rosec-uhid.service /usr/lib/systemd/system/rosec-uhid.service
+sudo install -Dm644 modules-load.conf  /usr/lib/modules-load.d/rosec-uhid.conf
+sudo systemctl enable --now rosec-uhid.socket
+```
+
+The `uhid` module must be loaded for `/dev/uhid` to exist — the
+`modules-load.d` file loads it at the next boot; to use it now without
+rebooting, `sudo modprobe uhid`. (The broker's unit is hardened with
+`ProtectKernelModules=yes`, so it cannot load the module itself.)
 
 Then enable the frontend for your session — set `fido2 = true` under
 `[service]` in your [configuration](configuration) and restart the daemon:
@@ -104,10 +118,9 @@ Then enable the frontend for your session — set `fido2 = true` under
 systemctl --user restart rosecd
 ```
 
-The `uhid` kernel module is loaded on demand. This is a per-user, opt-in
-desktop feature: each user's device is isolated (owned by that user at `0600`),
-so it is safe alongside other local users — there is just no reason to install
-the broker on a headless server.
+This is a per-user, opt-in desktop feature: each user's device is isolated
+(owned by that user at `0600`), so it is safe alongside other local users —
+there is just no reason to install the broker on a headless server.
 
 ## What runs where
 


### PR DESCRIPTION
## Why

FIDO2 / WebAuthn support (merged in #31) needs the privileged `rosec-uhid`
broker, but nothing packaged it — the `contrib/uhid/` units rode along in the
release tarball, yet no package installed them, and the `uhid` module load was
unhandled.

## What

`rosec-uhid` ships as a **separate, opt-in `rosec-uhid-bin` package** (like the
provider `-bin` packages), so users who don't want passkeys-in-browsers get
nothing extra — no root service, no `uhid` module loaded.

- **Release**: build the `rosec-uhid` binary and stage it into the per-target
  tarball (which already carries `contrib/`), plus an `aur-publish-uhid` job.
- **`PKGBUILD-uhid-bin`**: installs the broker binary, the socket/service
  units, and a `modules-load.d` file, with a post-install message covering the
  enable steps (`systemctl enable --now rosec-uhid.socket` + `fido2 = true`).
- **No hard dep on `rosec`** — the broker is standalone (rosecd connects to
  *it*, not the reverse). The relationship is expressed via `rosec`'s
  `optdepends` instead.
- **`modules-load.conf`** loads `uhid` at boot so `/dev/uhid` exists; the
  broker can't `modprobe` it itself (`ProtectKernelModules=yes`).

## Docs

Corrects a real bug I found: the install docs claimed the `uhid` module is
"loaded on demand", but `/dev/uhid` only exists once the module is loaded and
the hardened unit can't load it. Install docs now point at `rosec-uhid-bin` and
document the module-load requirement.

> Note: the release-workflow and AUR pieces can't be exercised without an
> actual release run; they mirror the existing provider `-bin` publish jobs.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk
