### PR TITLE
feat(packaging): add rosec-uhid-git source package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -715,3 +715,36 @@ jobs:
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
           commit_message: "Update to ${{ needs.prepare.outputs.version }}"
           force_push: true
+
+  # ---------------------------------------------------------------------------
+  # AUR rosec-uhid-git (VCS source package for the FIDO2 broker)
+  #
+  # The -git counterpart to rosec-uhid-bin: builds the broker from source HEAD.
+  # ---------------------------------------------------------------------------
+  aur-publish-uhid-git:
+    name: Publish rosec-uhid-git to AUR
+    runs-on: ubuntu-latest
+    needs: [prepare, release]
+    if: needs.prepare.outputs.is_release == 'true'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Render PKGBUILD from template
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          sed \
+            -e "s|@VERSION@|${VERSION}|g" \
+            contrib/aur/PKGBUILD-uhid-git > "$GITHUB_WORKSPACE/PKGBUILD-uhid-git-rendered"
+
+      - name: Publish to AUR
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.3
+        with:
+          pkgname: rosec-uhid-git
+          pkgbuild: ${{ github.workspace }}/PKGBUILD-uhid-git-rendered
+          assets: contrib/aur/rosec-uhid.install
+          commit_username: ${{ secrets.AUR_USERNAME }}
+          commit_email: ${{ secrets.AUR_EMAIL }}
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          commit_message: "Update to ${{ needs.prepare.outputs.version }}"
+          force_push: true

--- a/contrib/aur/PKGBUILD-uhid-bin
+++ b/contrib/aur/PKGBUILD-uhid-bin
@@ -33,7 +33,7 @@ optdepends=(
     'rosec: the Secret Service daemon that drives the virtual authenticator'
 )
 provides=('rosec-uhid')
-conflicts=('rosec-uhid')
+conflicts=('rosec-uhid' 'rosec-uhid-git')
 install=rosec-uhid.install
 
 source_x86_64=(

--- a/contrib/aur/PKGBUILD-uhid-git
+++ b/contrib/aur/PKGBUILD-uhid-git
@@ -1,0 +1,100 @@
+# Maintainer: John Mylchreest <jmylchreest@gmail.com>
+#
+# AUR VCS package: rosec-uhid-git
+#
+# Builds the rosec-uhid broker from source (latest git HEAD) — the privileged,
+# disposable half of rosec's FIDO2 / WebAuthn virtual authenticator. Install
+# this only if you want rosec to serve passkeys to browsers as a security key.
+#
+# The broker is standalone: it does not depend on rosec at runtime (rosecd
+# connects to *it*). rosec lists this in its optdepends.
+#
+# The release workflow renders this file by substituting @VERSION@.
+# At build time, pkgver() overrides the static version with the actual
+# git-derived version.
+
+pkgname=rosec-uhid-git
+pkgver=@VERSION@
+pkgrel=1
+pkgdesc="Privileged broker for rosec's FIDO2/WebAuthn virtual authenticator (git)"
+arch=('x86_64' 'aarch64')
+url="https://github.com/jmylchreest/rosec"
+license=('MIT')
+# See PKGBUILD-git: makepkg's -flto=auto produces GCC LTO IR that rust-lld
+# cannot link; Rust does its own LTO via the release profile.
+options=(!lto)
+optdepends=(
+    'rosec: the Secret Service daemon that drives the virtual authenticator'
+)
+makedepends=(
+    'git'
+    'rust'
+    'cargo'
+)
+provides=('rosec-uhid')
+conflicts=('rosec-uhid' 'rosec-uhid-bin')
+install=rosec-uhid.install
+
+source=("rosec-uhid-git::git+https://github.com/jmylchreest/rosec.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "${srcdir}/${pkgname}"
+    # Mirror PKGBUILD-git's version derivation.
+    local describe
+    describe=$(git describe --tags --long --match 'v[0-9]*')
+    if [[ $describe =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)-([0-9]+)-g([a-f0-9]+)$ ]]; then
+        local major=${BASH_REMATCH[1]}
+        local minor=${BASH_REMATCH[2]}
+        local patch=${BASH_REMATCH[3]}
+        local commits=${BASH_REMATCH[4]}
+        if (( commits == 0 )); then
+            printf '%s.%s.%s' "$major" "$minor" "$patch"
+        else
+            printf '%s.%s.%sdev%s' "$major" "$minor" "$((patch + 1))" "$commits"
+        fi
+    else
+        printf '0.0.0dev0'
+    fi
+}
+
+prepare() {
+    cd "${srcdir}/${pkgname}"
+    cargo fetch --locked 2>/dev/null || cargo fetch
+}
+
+build() {
+    cd "${srcdir}/${pkgname}"
+    cargo build --release --locked --bin rosec-uhid 2>/dev/null || \
+    cargo build --release          --bin rosec-uhid
+}
+
+check() {
+    cd "${srcdir}/${pkgname}"
+    cargo test --release --locked -p rosec-uhid 2>/dev/null || \
+    cargo test --release          -p rosec-uhid
+}
+
+package() {
+    cd "${srcdir}/${pkgname}"
+
+    # The privileged broker binary
+    install -Dm755 target/release/rosec-uhid \
+        "${pkgdir}/usr/bin/rosec-uhid"
+
+    # Socket-activated system service (not enabled by default — see the
+    # post-install message)
+    install -Dm644 contrib/uhid/rosec-uhid.socket \
+        "${pkgdir}/usr/lib/systemd/system/rosec-uhid.socket"
+    install -Dm644 contrib/uhid/rosec-uhid.service \
+        "${pkgdir}/usr/lib/systemd/system/rosec-uhid.service"
+
+    # Load the uhid module at boot so /dev/uhid exists (the broker's hardened
+    # unit cannot modprobe it itself)
+    install -Dm644 contrib/uhid/modules-load.conf \
+        "${pkgdir}/usr/lib/modules-load.d/rosec-uhid.conf"
+
+    # License
+    install -Dm644 LICENSE \
+        "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"
+}


### PR DESCRIPTION
## Why

`rosec-uhid-bin` only lands on the AUR at a tagged release. `rosec-uhid-git`
builds the FIDO2 broker from source HEAD, so it can be installed (or pushed to
the AUR) **now**, without waiting for a release — the counterpart to the
existing `rosec-git`.

## What

- `contrib/aur/PKGBUILD-uhid-git`: mirrors `rosec-git`'s `pkgver()` derivation,
  trimmed to build just the `rosec-uhid` binary (`cargo build --bin rosec-uhid`)
  and install it plus the socket/service units and the `modules-load.d` file.
  Standalone — no `rosec` dependency (expressed via `optdepends`).
- `aur-publish-uhid-git` job in the release workflow (mirrors `aur-publish-git`).
- `-bin` and `-git` broker packages are made mutually exclusive
  (`conflicts` + shared `provides=('rosec-uhid')`).

## Install now (before any release)

- Local build: render `@VERSION@` and `makepkg -si` against this PKGBUILD, or
- Push `rosec-uhid-git` to the AUR manually, then `paru -S rosec-uhid-git`.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk
