### PR TITLE
fix(uhid): security hardening — strip uaccess ACL + fd close-on-exec

### DIFF
--- a/contrib/aur/PKGBUILD-uhid-bin
+++ b/contrib/aur/PKGBUILD-uhid-bin
@@ -67,6 +67,11 @@ package() {
     install -Dm644 "${srcdir_inner}/contrib/uhid/modules-load.conf" \
         "${pkgdir}/usr/lib/modules-load.d/rosec-uhid.conf"
 
+    # Keep the seat-scoped uaccess ACL off the virtual authenticator node so a
+    # second local user cannot reach it (the broker owns it per-uid instead)
+    install -Dm644 "${srcdir_inner}/contrib/uhid/69-rosec-uhid.rules" \
+        "${pkgdir}/usr/lib/udev/rules.d/69-rosec-uhid.rules"
+
     # License
     install -Dm644 "${srcdir_inner}/LICENSE" \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/contrib/aur/PKGBUILD-uhid-git
+++ b/contrib/aur/PKGBUILD-uhid-git
@@ -94,6 +94,11 @@ package() {
     install -Dm644 contrib/uhid/modules-load.conf \
         "${pkgdir}/usr/lib/modules-load.d/rosec-uhid.conf"
 
+    # Keep the seat-scoped uaccess ACL off the virtual authenticator node so a
+    # second local user cannot reach it (the broker owns it per-uid instead)
+    install -Dm644 contrib/uhid/69-rosec-uhid.rules \
+        "${pkgdir}/usr/lib/udev/rules.d/69-rosec-uhid.rules"
+
     # License
     install -Dm644 LICENSE \
         "${pkgdir}/usr/share/licenses/${pkgname}/LICENSE"

--- a/contrib/uhid/69-rosec-uhid.rules
+++ b/contrib/uhid/69-rosec-uhid.rules
@@ -1,0 +1,19 @@
+# Keep the seat-scoped uaccess ACL off rosec's virtual FIDO2 authenticator.
+#
+# The device advertises the FIDO usage page by design, so the stock
+# 60-fido-id.rules sets ID_SECURITY_TOKEN=1 and 70-uaccess.rules would then
+# TAG+="uaccess" — making systemd-logind attach a POSIX ACL granting the
+# *active-seat* user read/write on the hidraw node. On a multi-user or
+# fast-user-switching host that lets another local user reach one user's
+# authenticator, defeating the broker's per-uid ownership. The broker chowns
+# the node to the specific requesting uid at 0600 instead; this rule stops the
+# competing ACL from ever being applied.
+#
+# This file MUST sort after 60-fido-id.rules and before 70-uaccess.rules.
+# Matched by rosec's fixed HID bus:vendor:product on the parent HID device
+# (0003:1209:0053) via KERNELS== — the identifiers live on the parent HID
+# device, not the hidraw node, and ENV{} does not walk parents. Only the root
+# broker can create such a device, since /dev/uhid is root-only.
+ACTION=="remove", GOTO="rosec_uhid_end"
+SUBSYSTEM=="hidraw", KERNELS=="0003:1209:0053.*", ENV{ID_SECURITY_TOKEN}="", ENV{ID_FIDO_TOKEN}="", TAG-="uaccess", TAG-="security-device"
+LABEL="rosec_uhid_end"

--- a/contrib/uhid/README.md
+++ b/contrib/uhid/README.md
@@ -33,6 +33,7 @@ install -Dm755 rosec-uhid            /usr/bin/rosec-uhid
 install -Dm644 rosec-uhid.socket     /usr/lib/systemd/system/rosec-uhid.socket
 install -Dm644 rosec-uhid.service    /usr/lib/systemd/system/rosec-uhid.service
 install -Dm644 modules-load.conf     /usr/lib/modules-load.d/rosec-uhid.conf
+install -Dm644 69-rosec-uhid.rules   /usr/lib/udev/rules.d/69-rosec-uhid.rules
 systemctl enable --now rosec-uhid.socket
 ```
 
@@ -42,21 +43,24 @@ file loads it at boot; the broker cannot load it itself (its unit sets
 
 ## hidraw ownership
 
-The broker chowns the created node to the requesting uid at `0600`. This is
-deliberately **not** left to the stock `fido_id` + `uaccess` rule, which
-grants the node to the active *seat* session — wrong for a seatless virtual
-device on a multi-user host (another logged-in user could enumerate it).
+The broker chowns the created node to the requesting uid at `0600`, so only
+that user can reach their authenticator.
 
-If you prefer a udev rule over the broker's own chown (e.g. for auditing),
-key it on rosec's vendor/product rather than the generic FIDO usage page, so
-it only ever matches rosec's own device:
+That chown is **not sufficient on its own**, and the shipped
+`69-rosec-uhid.rules` is required alongside it. The device advertises the FIDO
+usage page by design, so the stock `60-fido-id.rules` sets
+`ID_SECURITY_TOKEN=1` and `70-uaccess.rules` then tags it `uaccess` — which
+makes systemd-logind attach a POSIX ACL granting the **active-seat** user
+read/write, *in addition to* the owner. On a multi-user or fast-user-switching
+host that hands another local user access to the node, and logind re-applies
+it on every session change, so a one-time `chmod` cannot hold it off.
 
-```udev
-# /etc/udev/rules.d/70-rosec-uhid.rules
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", ATTRS{idProduct}=="0053", \
-    TAG+="uaccess"
+`69-rosec-uhid.rules` (installed to `/usr/lib/udev/rules.d/`) clears
+`ID_SECURITY_TOKEN` for rosec's device before `70-uaccess.rules` runs, so the
+ACL is never applied. It is matched by rosec's fixed HID vendor:product
+(`0003:1209:0053`), which only the root broker can create. Verify a granted
+node has no extra ACL entry:
+
+```sh
+getfacl /dev/hidrawN   # should show only the owner, no named-user uaccess entry
 ```
-
-Note the udev rule cannot know the *requesting* uid, so the broker's
-per-uid chown is the more precise mechanism on multi-user systems; the udev
-rule falls back to seat-scoped `uaccess`.

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -100,9 +100,10 @@ Or install it by hand from `contrib/uhid/` in the source tree:
 
 ```bash
 sudo install -Dm755 rosec-uhid         /usr/bin/rosec-uhid
-sudo install -Dm644 rosec-uhid.socket  /usr/lib/systemd/system/rosec-uhid.socket
-sudo install -Dm644 rosec-uhid.service /usr/lib/systemd/system/rosec-uhid.service
-sudo install -Dm644 modules-load.conf  /usr/lib/modules-load.d/rosec-uhid.conf
+sudo install -Dm644 rosec-uhid.socket   /usr/lib/systemd/system/rosec-uhid.socket
+sudo install -Dm644 rosec-uhid.service  /usr/lib/systemd/system/rosec-uhid.service
+sudo install -Dm644 modules-load.conf   /usr/lib/modules-load.d/rosec-uhid.conf
+sudo install -Dm644 69-rosec-uhid.rules /usr/lib/udev/rules.d/69-rosec-uhid.rules
 sudo systemctl enable --now rosec-uhid.socket
 ```
 

--- a/rosec-uhid/src/client.rs
+++ b/rosec-uhid/src/client.rs
@@ -74,11 +74,16 @@ fn recv_fd(stream: &UnixStream) -> Result<RawFd> {
     let mut buf = [0u8; 1];
     let mut iov = [IoSliceMut::new(&mut buf)];
     let mut cmsg_space = nix::cmsg_space!(RawFd);
+    // MSG_CMSG_CLOEXEC: the received fd must be close-on-exec so it does not
+    // leak into rosec-prompt (or any other) child processes the daemon spawns
+    // during a ceremony. Set atomically at receive time — a post-hoc
+    // fcntl(F_SETFD) would race a concurrent fork() on the multi-threaded
+    // runtime.
     let msg = recvmsg::<()>(
         stream.as_raw_fd(),
         &mut iov,
         Some(&mut cmsg_space),
-        MsgFlags::empty(),
+        MsgFlags::MSG_CMSG_CLOEXEC,
     )
     .context("recvmsg SCM_RIGHTS")?;
 


### PR DESCRIPTION
Security-review fixes for the FIDO2 virtual authenticator (new code). The two pre-existing secret-service/crypto findings (portal `app_id`, Tokio starvation, vault/DH zeroize) are handled in a separate PR.

## HIGH — strip the seat-scoped `uaccess` ACL from the virtual device

The authenticator advertises the FIDO usage page by design, so stock
`60-fido-id`/`70-uaccess` udev rules tag it and **systemd-logind grants the
active-seat user a POSIX ACL** on the hidraw node — bypassing the broker's
per-uid `chown` entirely. Worse, logind re-applies it on every session/seat
change, so the broker's one-time `chmod 0600` can't hold it off. On a
multi-user / fast-user-switch host, user B (active seat) gets `rw` on user A's
authenticator and can drive raw CTAPHID at it.

Fix: ship a **mandatory** `69-rosec-uhid.rules` (installed by both broker
packages) that clears `ID_SECURITY_TOKEN` for rosec's HID vendor:product
(`KERNELS=="0003:1209:0053.*"`) before `70-uaccess` runs, so the ACL is never
applied. **Verified live** — a freshly granted node shows `CURRENT_TAGS=:seat:`
and a clean `getfacl` (owner-only, no named-user entry). The README/install
docs are corrected — they previously called the rule "optional, for auditing"
and even suggested `TAG+="uaccess"` (which *grants* seat access).

## MEDIUM — uhid device fd was not close-on-exec

`recv_fd` used `MsgFlags::empty()`, so the `/dev/uhid` fd inherited into every
`rosec-prompt` child spawned during a ceremony. Fix: `MSG_CMSG_CLOEXEC` (set
atomically at receive to avoid a fork race).

Builds clean, `rosec-uhid` 51 tests pass.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk
