### PR TITLE
fix(secret-service): security hardening — portal caller auth, pipe DoS, zeroize

### DIFF
--- a/rosec-secret-service/src/crypto.rs
+++ b/rosec-secret-service/src/crypto.rs
@@ -20,7 +20,7 @@ use hkdf::Hkdf;
 use num_bigint::BigUint;
 use rosec_core::ProviderError;
 use sha2::Sha256;
-use zeroize::Zeroizing;
+use zeroize::{Zeroize, Zeroizing};
 
 /// The 1024-bit MODP prime from RFC 2409 §6.2.
 ///
@@ -194,10 +194,19 @@ pub fn aes128_cbc_decrypt(
 /// `BigUint::to_bytes_be()` omits leading zeros; the DH public key and shared
 /// secret must be exactly 128 bytes for the spec to work correctly.
 fn pad_to_128(mut bytes: Vec<u8>) -> Vec<u8> {
-    while bytes.len() < DH_KEY_BYTES {
-        bytes.insert(0, 0);
+    // Mod-p values never exceed 128 bytes; nothing to pad.
+    if bytes.len() >= DH_KEY_BYTES {
+        return bytes;
     }
-    bytes
+    // Build the result in a single pre-sized buffer. A growing `insert(0, 0)`
+    // loop reallocates and leaves stray copies of the (possibly secret) bytes
+    // in freed heap; copy once and scrub the input instead. NOTE: the source
+    // `BigUint` itself still holds un-scrubbed limbs — num-bigint has no
+    // zeroize support; fully scrubbing needs a bignum migration.
+    let mut out = vec![0u8; DH_KEY_BYTES];
+    out[DH_KEY_BYTES - bytes.len()..].copy_from_slice(&bytes);
+    bytes.zeroize();
+    out
 }
 
 #[cfg(test)]

--- a/rosec-secret-service/src/daemon/management.rs
+++ b/rosec-secret-service/src/daemon/management.rs
@@ -368,40 +368,10 @@ impl RosecManagement {
         let state = Arc::clone(&self.state);
         self.state
             .run_on_tokio(async move {
-                // Read password from the pipe into a zeroizing buffer.
-                let password = {
-                    use std::io::Read as _;
-                    // SAFETY: raw is a valid fd from dup() above.
-                    let file = unsafe { std::os::unix::io::FromRawFd::from_raw_fd(raw) };
-                    let mut file: std::fs::File = file;
-                    let mut buf = zeroize::Zeroizing::new(Vec::with_capacity(256));
-                    file.read_to_end(&mut buf)
-                        .map_err(|e| FdoError::Failed(format!("read from pipe failed: {e}")))?;
-                    // file is dropped here → fd closed
-
-                    // Strip trailing null byte (pam_exec null-terminates).
-                    if buf.last() == Some(&0) {
-                        buf.pop();
-                    }
-                    // Strip trailing newline.
-                    if buf.last() == Some(&b'\n') {
-                        buf.pop();
-                    }
-
-                    if buf.is_empty() {
-                        return Err(FdoError::Failed("pipe password is empty".to_string()));
-                    }
-
-                    // Validate UTF-8 against the zeroizing buffer; on success
-                    // copy into a Zeroizing<String>, on failure leave the bytes
-                    // in `buf` (which scrubs on drop). std::mem::take here
-                    // would move the Vec out of the Zeroizing wrapper and the
-                    // UTF-8 error path would drop a non-zeroizing Vec.
-                    let s = std::str::from_utf8(&buf).map_err(|_| {
-                        FdoError::Failed("pipe password is not valid UTF-8".to_string())
-                    })?;
-                    zeroize::Zeroizing::new(s.to_owned())
-                };
+                // Read the password off the pipe on a blocking thread bounded
+                // by a timeout, so a caller that never writes cannot pin a
+                // runtime worker (see read_pipe_password).
+                let password = read_pipe_password(raw, "auth").await?;
 
                 // Look up the password field ID for this provider.
                 let provider = state.provider_by_id(&provider_id).ok_or_else(|| {
@@ -591,42 +561,11 @@ impl RosecManagement {
         let state = Arc::clone(&self.state);
         self.state
             .run_on_tokio(async move {
-                // Helper: read a password from a pipe fd into Zeroizing<String>.
-                let read_pipe_password =
-                    |raw_fd: libc::c_int,
-                     name: &str|
-                     -> Result<zeroize::Zeroizing<String>, FdoError> {
-                        use std::io::Read as _;
-                        let file: std::fs::File =
-                            unsafe { std::os::unix::io::FromRawFd::from_raw_fd(raw_fd) };
-                        let mut file = file;
-                        let mut buf = zeroize::Zeroizing::new(Vec::with_capacity(256));
-                        file.read_to_end(&mut buf).map_err(|e| {
-                            FdoError::Failed(format!("read from {name} pipe failed: {e}"))
-                        })?;
-                        // file dropped here → fd closed
-
-                        // Strip trailing null byte (pam_exec null-terminates).
-                        if buf.last() == Some(&0) {
-                            buf.pop();
-                        }
-                        // Strip trailing newline.
-                        if buf.last() == Some(&b'\n') {
-                            buf.pop();
-                        }
-
-                        if buf.is_empty() {
-                            return Err(FdoError::Failed(format!("{name} password is empty")));
-                        }
-
-                        let s = String::from_utf8(std::mem::take(&mut *buf)).map_err(|_| {
-                            FdoError::Failed(format!("{name} password is not valid UTF-8"))
-                        })?;
-                        Ok(zeroize::Zeroizing::new(s))
-                    };
-
-                let old_password = read_pipe_password(old_raw, "old")?;
-                let new_password = read_pipe_password(new_raw, "new")?;
+                // Read both passwords off the pipes on blocking threads bounded
+                // by a timeout (see read_pipe_password), so a caller that never
+                // writes cannot pin a runtime worker.
+                let old_password = read_pipe_password(old_raw, "old").await?;
+                let new_password = read_pipe_password(new_raw, "new").await?;
 
                 let provider = state.provider_by_id(&provider_id).ok_or_else(|| {
                     FdoError::Failed(format!("provider '{provider_id}' not found"))
@@ -638,6 +577,62 @@ impl RosecManagement {
                     .map_err(|e| FdoError::Failed(format!("change_password failed: {e}")))
             })
             .await?
+    }
+}
+
+/// Give up waiting for a password on a caller-supplied pipe after this long,
+/// so a peer that passes a pipe and never writes cannot tie up a thread.
+const PIPE_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Blocking read of a password from a raw pipe fd into a `Zeroizing<String>`.
+/// Takes ownership of `raw` and closes it on return.
+fn read_pipe_password_blocking(
+    raw: std::os::unix::io::RawFd,
+    name: &str,
+) -> Result<zeroize::Zeroizing<String>, FdoError> {
+    use std::io::Read as _;
+    use std::os::unix::io::FromRawFd as _;
+    // SAFETY: `raw` is a valid, owned dup'd fd handed to this function.
+    let mut file = unsafe { std::fs::File::from_raw_fd(raw) };
+    let mut buf = zeroize::Zeroizing::new(Vec::with_capacity(256));
+    file.read_to_end(&mut buf)
+        .map_err(|e| FdoError::Failed(format!("read from {name} pipe failed: {e}")))?;
+    // Strip a trailing null (pam_exec null-terminates) then a trailing newline.
+    if buf.last() == Some(&0) {
+        buf.pop();
+    }
+    if buf.last() == Some(&b'\n') {
+        buf.pop();
+    }
+    if buf.is_empty() {
+        return Err(FdoError::Failed(format!("{name} password is empty")));
+    }
+    // Validate UTF-8 against the zeroizing buffer and copy into a
+    // Zeroizing<String>; a mem::take would move the bytes out of the zeroizing
+    // wrapper and drop a plain Vec on the error path.
+    let s = std::str::from_utf8(&buf)
+        .map_err(|_| FdoError::Failed(format!("{name} password is not valid UTF-8")))?;
+    Ok(zeroize::Zeroizing::new(s.to_owned()))
+}
+
+/// Read a password from a caller-supplied pipe fd *off* the async runtime: the
+/// blocking read runs on a `spawn_blocking` thread and is bounded by
+/// [`PIPE_READ_TIMEOUT`]. A caller that passes a pipe read-end and never writes
+/// therefore cannot pin a Tokio worker — which would otherwise starve the
+/// runtime that every provider/secret operation funnels through.
+async fn read_pipe_password(
+    raw: std::os::unix::io::RawFd,
+    name: &'static str,
+) -> Result<zeroize::Zeroizing<String>, FdoError> {
+    let handle = tokio::task::spawn_blocking(move || read_pipe_password_blocking(raw, name));
+    match tokio::time::timeout(PIPE_READ_TIMEOUT, handle).await {
+        Ok(join) => {
+            join.map_err(|e| FdoError::Failed(format!("{name} pipe read task failed: {e}")))?
+        }
+        Err(_) => Err(FdoError::Failed(format!(
+            "{name} password pipe read timed out after {}s",
+            PIPE_READ_TIMEOUT.as_secs()
+        ))),
     }
 }
 

--- a/rosec-secret-service/src/portal.rs
+++ b/rosec-secret-service/src/portal.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use rand::Rng;
+use zbus::Connection;
 use zbus::fdo::Error as FdoError;
 use zbus::interface;
 use zbus::message::Header;
@@ -29,6 +30,11 @@ const PORTAL_SCHEMA: &str = "org.freedesktop.portal.Secret";
 /// The attribute key used to look up portal secrets by application ID.
 const PORTAL_ATTR_APP_ID: &str = "app_id";
 
+/// Well-known name of the trusted xdg-desktop-portal broker. Only that process
+/// may drive this backend — it derives `app_id` from the sandboxed peer, so a
+/// direct session-bus caller passing a forged `app_id` must be refused.
+const PORTAL_BUS_NAME: &str = "org.freedesktop.portal.Desktop";
+
 const PORTAL_ATTR_SCHEMA: &str = "xdg:schema";
 
 /// Size of the per-app secret in bytes (matches gnome-keyring, oo7, and KWallet).
@@ -42,6 +48,27 @@ enum PortalLookup {
     /// Secret exists but the provider is locked — caller should not generate
     /// a replacement (that would silently overwrite the real secret).
     Locked,
+}
+
+/// Verify the D-Bus caller is the xdg-desktop-portal broker — the current
+/// owner of [`PORTAL_BUS_NAME`]. Fail-closed: an absent sender or an
+/// unresolvable name owner is treated as untrusted, so this backend never
+/// hands out or overwrites a secret for a forged `app_id` passed by an
+/// arbitrary session-bus peer.
+async fn caller_is_portal(header: &Header<'_>, conn: &Connection) -> bool {
+    let Some(sender) = header.sender() else {
+        return false;
+    };
+    let Ok(proxy) = zbus::fdo::DBusProxy::new(conn).await else {
+        return false;
+    };
+    let Ok(name) = zbus::names::BusName::try_from(PORTAL_BUS_NAME) else {
+        return false;
+    };
+    match proxy.get_name_owner(name).await {
+        Ok(owner) => owner.as_str() == sender.as_str(),
+        Err(_) => false,
+    }
 }
 
 pub struct PortalSecret {
@@ -67,14 +94,29 @@ impl PortalSecret {
         fd: zvariant::OwnedFd,
         _options: HashMap<String, OwnedValue>,
         #[zbus(header)] header: Header<'_>,
+        #[zbus(connection)] conn: &Connection,
     ) -> Result<(u32, HashMap<String, OwnedValue>), FdoError> {
         crate::daemon::log_dbus_caller("portal", "RetrieveSecret", &header);
+
+        // Only xdg-desktop-portal may drive this backend — it derives app_id
+        // from the sandboxed peer's identity. Refuse a direct session-bus
+        // caller passing a forged app_id, which could otherwise read or
+        // overwrite (replace=true) another application's secret.
+        if !caller_is_portal(&header, conn).await {
+            tracing::warn!(
+                app_id,
+                "portal: refusing RetrieveSecret from a caller that is not xdg-desktop-portal"
+            );
+            return Err(FdoError::AccessDenied(
+                "org.freedesktop.impl.portal.Secret may only be called by xdg-desktop-portal"
+                    .to_string(),
+            ));
+        }
+
         self.state.touch_activity();
 
         tracing::info!(app_id, "portal: RetrieveSecret");
 
-        // Defense-in-depth: xdg-desktop-portal validates app_id against the
-        // sandbox, but direct D-Bus callers can pass anything.
         if app_id.is_empty() {
             tracing::warn!("portal: rejecting empty app_id");
             return Ok((2, HashMap::new()));

--- a/rosec-vault/src/provider.rs
+++ b/rosec-vault/src/provider.rs
@@ -226,7 +226,10 @@ impl LocalVault {
             .map_err(|e| ProviderError::Other(e.into()))?;
         let wrapping_entries = vec![entry];
 
-        let plaintext = serde_json::to_vec(&data).map_err(|e| ProviderError::Other(e.into()))?;
+        // Zeroizing: the serialized plaintext holds every secret in the vault;
+        // scrub the buffer on drop rather than leaving it in freed heap.
+        let plaintext =
+            Zeroizing::new(serde_json::to_vec(&data).map_err(|e| ProviderError::Other(e.into()))?);
         let encrypted = crypto::encrypt(&plaintext, &*vault_key);
         let hmac = crypto::compute_hmac(&*mac_key, &encrypted)
             .map_err(|e| ProviderError::Other(e.into()))?;
@@ -258,8 +261,11 @@ impl LocalVault {
             return Ok(());
         }
 
-        let plaintext =
-            serde_json::to_vec(&state.data).map_err(|e| ProviderError::Other(e.into()))?;
+        // Zeroizing: the serialized plaintext holds every secret in the vault;
+        // scrub the buffer on drop rather than leaving it in freed heap.
+        let plaintext = Zeroizing::new(
+            serde_json::to_vec(&state.data).map_err(|e| ProviderError::Other(e.into()))?,
+        );
         let encrypted = crypto::encrypt(&plaintext, &*state.vault_key);
         let hmac = crypto::compute_hmac(&*state.mac_key, &encrypted)
             .map_err(|e| ProviderError::Other(e.into()))?;


### PR DESCRIPTION
The pre-existing secret-service/crypto findings from the security review (the new-code FIDO2 fixes are in #34). All verified against the code before fixing; every finding is same-uid-reachable (Secret Service's baseline trust model), so these are availability/hygiene/defense-in-depth hardening rather than privilege-boundary breaks.

## MED-HIGH — portal `RetrieveSecret` trusted caller-supplied `app_id`

`org.freedesktop.impl.portal.Secret` must only be driven by xdg-desktop-portal
(which derives `app_id` from the sandboxed peer). It performed no peer check, so
a direct session-bus caller could pass a forged `app_id` to read — or, via the
`replace=true` create path, **overwrite** — another app's secret. Now verifies
the sender is the current owner of `org.freedesktop.portal.Desktop` and refuses
otherwise (`AccessDenied`), fail-closed.

## MED — Tokio worker starvation on the pipe-auth methods

`AuthProviderFromPipe` / `ChangeProviderPassword` did a synchronous
`read_to_end` on a caller-passed pipe fd directly on a Tokio worker (via
`run_on_tokio`). A caller that never writes pinned workers and stalled every
secret operation the runtime funnels through (also triggerable *accidentally*
by a client that opens the pipe then dies). Both now read via one shared helper
on a `spawn_blocking` thread bounded by a 30s timeout. Also removes a
`mem::take` that dropped a non-zeroizing `Vec` on the UTF-8 error path.

## MED — vault plaintext not zeroized

`save()`/`create_vault` serialized the entire vault (every secret) into a plain
`Vec` left in freed heap. Wrapped in `Zeroizing`.

## LOW-MED — DH shared-secret stray copies

`pad_to_128` grew the buffer with `insert(0, 0)`, reallocating and leaving stray
copies of the shared secret in freed heap. Now builds the padded buffer once and
scrubs the input. (The `num-bigint` `BigUint` limbs themselves stay un-scrubbed
— num-bigint has no zeroize support; a full scrub needs a bignum migration,
noted in code and left as a follow-up rather than a risky rewrite of the
interop-critical DH.)

Builds clean, full workspace test suite (381) passes.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk
