### PR TITLE
docs: Secret Portal page + FAQ accuracy + undocumented commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Or via the CLI: `rosec totp get github`.
 
 A handful of greatest hits — the [FAQ on the docs site](https://jmylchreest.github.io/rosec/faq) has the full set.
 
-**Is this a drop-in for GNOME Keyring?** For the Secret Service API, yes. PKCS#11 and the gnome-keyring SSH agent are not implemented; if you depend on those keep gnome-keyring around alongside.
+**Is this a drop-in for GNOME Keyring?** For the Secret Service API, yes — and rosec ships its own SSH agent (serving keys from your providers), so `rosec enable` even masks gnome-keyring's SSH autostart. The one component it does not provide is the **PKCS#11** module (certificate / crypto-token storage); if you depend on that, keep gnome-keyring installed for it alone.
 
 **Does the daemon sync between machines?** No — rosec is a local daemon. Sync happens within individual providers (Bitwarden API, KeePassXC kdbx via Syncthing, etc.).
 

--- a/docs/docs/cli.md
+++ b/docs/docs/cli.md
@@ -68,3 +68,14 @@ Triggers a sync on all providers that declare the `Sync` capability. Providers w
 ## TOTP
 
 `rosec totp [get|add]` reads and stores time-based one-time passwords. Codes are also exposed via the FUSE mount at `$XDG_RUNTIME_DIR/rosec/totp/` and the `GetTotpCode` D-Bus method. Full reference: [TOTP](./totp).
+
+## Backup & migration (export / import)
+
+`rosec item export` writes a single item — selected by ID or a `key=value` filter — to TOML on stdout, secrets included. `rosec item import` reads that format back, into the first writable provider (or `--provider`); `--force` overwrites an item with the same attributes.
+
+```bash
+rosec item export github > github.toml     # dump one item to TOML
+rosec item import --force < github.toml     # restore it (secrets included)
+```
+
+Because export includes secret values, treat the output as sensitive.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -2,6 +2,19 @@
 
 Config file: `$XDG_CONFIG_HOME/rosec/config.toml` (default: `~/.config/rosec/config.toml`)
 
+## Editing from the CLI
+
+Read or change individual settings without opening the file — the daemon
+hot-reloads on `set`:
+
+```bash
+rosec config show                                 # print the resolved config
+rosec config get autolock.idle_timeout_minutes    # read one dotted key
+rosec config set service.refresh_interval_secs 120
+```
+
+The reference below documents every key.
+
 ---
 
 ## `[service]`

--- a/docs/docs/faq.md
+++ b/docs/docs/faq.md
@@ -8,9 +8,13 @@ sidebar_position: 99
 
 For the Secret Service API, yes. Applications using `libsecret`, `secret-tool`, or talking to `org.freedesktop.secrets` directly will work unchanged. `rosec enable` writes the systemd / D-Bus activation files needed to take over the bus name from `gnome-keyring-daemon` and masks the upstream service so it doesn't fight you on login.
 
-The PKCS#11 store and the Secrets-PIN-Entry agent that `gnome-keyring-daemon` ships are **not** implemented — if you depend on those, keep gnome-keyring around alongside.
+The one `gnome-keyring-daemon` component rosec doesn't provide is the **PKCS#11** module (certificate and crypto-token storage) — if you depend on that, keep gnome-keyring installed for it alone. Its SSH agent *is* covered: rosec ships its own (see [Where do SSH keys come from?](#where-do-ssh-keys-come-from) below), and `rosec enable` masks gnome-keyring's SSH autostart so the two don't both try to own the agent.
 
 If you have existing `~/.local/share/keyrings/*.keyring` files, the `gnome-keyring` provider mounts them read-only inside rosec so you can migrate without retyping every secret. See [Providers → GNOME Keyring](./providers/capabilities).
+
+## Can Flatpak apps use rosec?
+
+Yes. rosec implements the XDG Desktop Portal's Secret backend, so sandboxed apps get their secrets from your providers automatically — including ones originally stored by gnome-keyring or oo7. See [Flatpak app secrets](./portal).
 
 ## Why does `gnome-keyring-daemon` keep stealing the bus name back?
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -60,6 +60,19 @@ busctl --user list | grep secrets
 
 If `gnome-keyring-daemon` keeps grabbing the bus name on login, rerun `rosec enable --force` and check the [Troubleshooting guide](./troubleshooting).
 
+## Disabling rosec
+
+To hand the Secret Service back to gnome-keyring, `rosec disable` removes the
+D-Bus activation overrides and un-hides the upstream autostart files:
+
+```bash
+rosec disable
+systemctl --user stop rosecd
+```
+
+Your providers and config are left untouched — rerun `rosec enable` to switch
+back.
+
 ## Add your first provider
 
 ```bash

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -15,6 +15,7 @@ It also bundles two FUSE filesystems and an SSH agent, so secrets stored in any 
 - **Stays out of the way.** Drop-in for GNOME Keyring; `rosec enable` writes the same systemd / D-Bus activation files Keyring would, masking the upstream service.
 - **Useful without writing code.** SSH keys discovered in any provider auto-populate the bundled SSH agent; TOTP seeds appear as live files under `$XDG_RUNTIME_DIR/rosec/totp/`. PAM unlock means your master password is the same as your login.
 - **Sandboxed plugins.** Non-built-in providers (Bitwarden, KeePassXC, gnome-keyring) run as Extism WASM guests with per-file allow-listing — the daemon hosts the network/filesystem capabilities they need; the plugin can't touch anything you didn't authorise.
+- **Sandboxed apps too.** rosec implements the XDG Secret portal, so Flatpak apps retrieve their secrets from your providers — see [Flatpak app secrets](./portal).
 
 ## Status
 

--- a/docs/docs/portal.md
+++ b/docs/docs/portal.md
@@ -1,0 +1,43 @@
+---
+sidebar_position: 5
+title: Flatpak app secrets
+---
+
+# Flatpak app secrets (Secret Portal)
+
+Sandboxed applications can't reach the Secret Service bus directly — they go
+through the [XDG Desktop Portal](https://flatpak.github.io/xdg-desktop-portal/).
+rosec implements the portal's **Secret** backend
+(`org.freedesktop.impl.portal.Secret`), so Flatpak and other confined apps get
+their secrets from your rosec providers with no extra setup. `rosec enable`
+installs the portal backend automatically.
+
+## How it works
+
+Each confined app has a stable **app ID** (for example
+`com.belmoussaoui.Authenticator`). When the app asks the portal for its secret,
+rosec:
+
+1. Searches your providers for an item whose `app_id` attribute matches, ranked
+   by provider priority (then by whether it carries an `xdg:schema` hint).
+2. If one exists, returns its secret. If not, it **generates a random secret,
+   stores it** in your first writable provider, and returns that — so the app
+   gets the same secret on every launch.
+
+The secret is written straight to the app's file descriptor and never appears on
+the bus. If your vault is **locked**, the request fails cleanly (the app sees no
+secret) until you unlock.
+
+## Migrating from gnome-keyring or oo7
+
+rosec reads portal secrets that `gnome-keyring-daemon` or `oo7-portal` already
+stored: it matches on `app_id` and accepts the secret under either the `secret`
+or `password` attribute, so existing Flatpak apps keep working after you switch.
+
+## Inspecting a portal secret
+
+Portal items are ordinary vault items — find one by its `app_id` attribute:
+
+```bash
+rosec search app_id=com.belmoussaoui.Authenticator
+```

--- a/docs/docs/ssh-agent.md
+++ b/docs/docs/ssh-agent.md
@@ -76,11 +76,11 @@ SSH_AUTH_SOCK="$XDG_RUNTIME_DIR/rosec/agent.sock" ssh-add -l
 
 ## SSH Key Sources
 
-rosec discovers SSH keys from any vault item regardless of type.  Two sources are supported:
+rosec discovers SSH keys from any vault item regardless of type.  Three sources are supported:
 
 ### Native SSH Key items (type `sshkey`)
 
-Vault backends that have a first-class SSH key type (e.g. Bitwarden's native SSH Key item) expose the key directly.  rosec uses the `private_key` field for signing and derives the public key automatically.
+Vault backends that have a first-class SSH key type (e.g. Bitwarden's native SSH Key item) expose the key directly.  rosec uses the `private_key` field for signing and derives the public key automatically. To create one in your local vault, `rosec item add --type=ssh-key --generate-ssh-key` mints an ed25519 key pair and stores it.
 
 ### KeePassXC SSH Agent integration
 


### PR DESCRIPTION
Accuracy fixes plus docs for functionality that existed but wasn't written up.

## Accuracy
- **"Drop-in for GNOME Keyring" FAQ** (README + faq.md) claimed rosec's *SSH agent* isn't implemented. It **is** — rosec ships its own, and `rosec enable` even masks `gnome-keyring-ssh.desktop`. `gnome-keyring-daemon` ships `secrets` + `ssh` + `pkcs11`; rosec covers the first two, so the **only** gap is **PKCS#11**. Reworded both (the old README line even contradicted its own "SSH agent" feature row).
- **ssh-agent.md** said "Two sources" but lists three.

## New functionality docs
- **New page `portal.md`** — the **XDG Secret Portal** backend (`org.freedesktop.impl.portal.Secret`): Flatpak/confined apps get per-app secrets from rosec, generated + persisted on first request, gnome-keyring/oo7 compatible. Linked from intro + FAQ. (The README already advertised it; the docs site had no page.)
- **`rosec disable`** → installation.md (the revert of `enable`).
- **`rosec config show/get/set`** → configuration.md.
- **`rosec item export` / `import`** → cli.md (backup & migration).
- **`rosec item add --type=ssh-key --generate-ssh-key`** → ssh-agent.md.

All verified against the implementation; British spelling; matches surrounding voice. Skipped `provider attach`/key-wrapping — already covered in providers/local.md.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk
