### PR TITLE
fix(totp): satisfy newer clippy redundant-reference lint

### DIFF
--- a/rosec-core/src/totp.rs
+++ b/rosec-core/src/totp.rs
@@ -190,7 +190,7 @@ fn decode_base32(input: &str) -> Result<Zeroizing<Vec<u8>>, TotpError> {
 
     // Re-pad to a multiple of 8 for the decoder.
     let pad_len = (8 - cleaned.len() % 8) % 8;
-    let padded = Zeroizing::new(format!("{}{}", &*cleaned, "=".repeat(pad_len)));
+    let padded = Zeroizing::new(format!("{}{}", cleaned.as_str(), "=".repeat(pad_len)));
 
     data_encoding::BASE32
         .decode(padded.as_bytes())


### PR DESCRIPTION
One-line lint fix unblocking CI on `main`. CI's clippy (newer than local 0.1.95) flags `&*cleaned` in the base32 re-pad `format!` as a redundant reference; switched to `cleaned.as_str()`. No behaviour change; verified with `cargo clippy --workspace --locked -- -D warnings`. Pre-existing on main (surfaced by a runner toolchain bump), not from the recent refactor/docs.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk