### PR TITLE
fix: clear remaining clippy 1.97 lints (unblock CI)

### DIFF
--- a/rosec-fuse/src/totp_fs.rs
+++ b/rosec-fuse/src/totp_fs.rs
@@ -202,7 +202,7 @@ impl SynthSnapshot for Snapshot {
             warn!(error = %e, "TOTP code generation failed");
             Errno::EIO
         })?;
-        let content = Zeroizing::new(format!("{}\n", &*code));
+        let content = Zeroizing::new(format!("{}\n", code.as_str()));
         let bytes = content.as_bytes();
         let start = (offset as usize).min(bytes.len());
         let end = (start + size as usize).min(bytes.len());

--- a/rosec-wasm/src/host_http.rs
+++ b/rosec-wasm/src/host_http.rs
@@ -197,7 +197,7 @@ fn http_request_impl(
     // value drops at end of scope. Best-effort: we can't change the upstream
     // type, but we can overwrite the contents in place via zeroize.
     use zeroize::Zeroize as _;
-    for (_, v) in req.headers.iter_mut() {
+    for v in req.headers.values_mut() {
         v.zeroize();
     }
 

--- a/rosec/src/totp/add.rs
+++ b/rosec/src/totp/add.rs
@@ -79,7 +79,7 @@ pub async fn run(args: TotpAddArgs) -> Result<()> {
             bail!("cancelled");
         }
     } else {
-        eprintln!("Current code: {}", &*test_code);
+        eprintln!("Current code: {}", test_code.as_str());
         eprint!("Does this match? [y/N] ");
         let mut buf = String::new();
         std::io::stdin().read_line(&mut buf)?;


### PR DESCRIPTION
The earlier totp.rs fix wasn't the whole set — CI's clippy 1.97 flags three more that local 0.1.95 missed. I updated the local toolchain to 1.97 to match CI and swept the workspace, so this should be the last of them.

- `totp_fs.rs`, `totp/add.rs`: redundant `&*` reference in a format arg → `.as_str()`
- `host_http.rs`: `for_kv_map` → `values_mut()`

No behaviour change; `cargo clippy --workspace --locked -- -D warnings` is clean on 1.97.

https://claude.ai/code/session_01MrZnqq9WL6YG9vBV7RHhpk