### PR TITLE
fix(core): key dedup on attribute hashes for locked items

### DIFF
--- a/rosec-core/src/dedup.rs
+++ b/rosec-core/src/dedup.rs
@@ -36,9 +36,16 @@ pub fn dedup(
         // identity and may differ across providers.  Two items from different
         // providers that share the same label and the same client-visible
         // attributes should be considered duplicates.
-        let mut attrs: Vec<(String, String)> = item
-            .attributes
-            .iter()
+        // Sidecar-sourced items (provider locked) carry attribute names with
+        // blank values, so deduping on those collapses distinct items sharing a
+        // label and key set — the losers vanish from `SearchItems` and libsecret
+        // clients overwrite the survivor as if no key existed.  The HMAC
+        // fingerprints stay distinct while locked, so key on those instead.
+        let source: Box<dyn Iterator<Item = (&String, &String)>> = match &item.attribute_hashes {
+            Some(hashes) => Box::new(hashes.iter()),
+            None => Box::new(item.attributes.iter()),
+        };
+        let mut attrs: Vec<(String, String)> = source
             .filter(|(k, _)| !k.starts_with("rosec:") && !k.starts_with("xdg:"))
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
@@ -333,5 +340,47 @@ mod tests {
             result.items[0].provider_id, "local",
             "local item is newer and should win"
         );
+    }
+
+    /// Two "Chromium Safe Storage" items differing only by `application`
+    /// (Signal vs chromium) are indistinguishable once locked, since the
+    /// sidecar blanks attribute values.  Collapsing them loses one from
+    /// `SearchItems`, and libsecret clients then overwrite the survivor.
+    #[test]
+    fn locked_items_dedup_on_hashes_not_blank_values() {
+        let mut signal = meta("signal", "local", "Chromium Safe Storage", None);
+        signal.locked = true;
+        signal.attributes = Attributes::from([
+            ("application".to_string(), String::new()),
+            ("xdg:schema".to_string(), String::new()),
+        ]);
+        signal.attribute_hashes = Some(HashMap::from([
+            ("application".to_string(), "hash-of-Signal".to_string()),
+            ("xdg:schema".to_string(), "hash-of-schema".to_string()),
+        ]));
+
+        let mut chromium = meta("chromium", "local", "Chromium Safe Storage", None);
+        chromium.locked = true;
+        chromium.attributes = signal.attributes.clone();
+        chromium.attribute_hashes = Some(HashMap::from([
+            ("application".to_string(), "hash-of-chromium".to_string()),
+            ("xdg:schema".to_string(), "hash-of-schema".to_string()),
+        ]));
+
+        let config = DedupConfig {
+            strategy: DedupStrategy::Newest,
+            time_fallback: DedupTimeFallback::Created,
+        };
+        let map = provider_priority_map(vec!["local".into()]);
+        let result = dedup(vec![signal, chromium], config, &map);
+
+        assert_eq!(
+            result.items.len(),
+            2,
+            "locked items with distinct attribute hashes must not be collapsed"
+        );
+        let mut ids: Vec<&str> = result.items.iter().map(|i| i.id.as_str()).collect();
+        ids.sort();
+        assert_eq!(ids, vec!["chromium", "signal"]);
     }
 }

--- a/rosec-secret-service/src/tty.rs
+++ b/rosec-secret-service/src/tty.rs
@@ -245,3 +245,81 @@ pub async fn collect_tty_on_fd(
     }
     Ok(map)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Allocate a pty pair.  `read_hidden` drives `tcgetattr`/`tcsetattr` on the
+    /// fd, which fail with ENOTTY on a pipe — only a real terminal will do.
+    fn openpty_pair() -> (RawFd, RawFd) {
+        let mut master: RawFd = -1;
+        let mut slave: RawFd = -1;
+        let rc = unsafe {
+            libc::openpty(
+                &mut master,
+                &mut slave,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            )
+        };
+        assert_eq!(rc, 0, "openpty failed: {}", io::Error::last_os_error());
+        (master, slave)
+    }
+
+    #[test]
+    fn read_hidden_reads_a_line_from_a_pty() {
+        use std::io::Write as _;
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let (master, slave) = openpty_pair();
+
+        // `read_hidden` installs its termios with TCSAFLUSH, which discards
+        // anything already queued.  A single write racing that setup is silently
+        // dropped and the read blocks forever, so keep offering the line until
+        // one lands after the flush.
+        let done = Arc::new(AtomicBool::new(false));
+        let reader = {
+            let done = Arc::clone(&done);
+            std::thread::spawn(move || {
+                let r = read_hidden(slave, None);
+                done.store(true, Ordering::SeqCst);
+                r
+            })
+        };
+
+        let mut w = unsafe { <std::fs::File as std::os::unix::io::FromRawFd>::from_raw_fd(master) };
+        while !done.load(Ordering::SeqCst) {
+            let _ = writeln!(w, "hunter2");
+            let _ = w.flush();
+            std::thread::sleep(std::time::Duration::from_millis(20));
+        }
+
+        let got = reader.join().expect("reader thread").expect("read_hidden");
+        assert_eq!(&*got, "hunter2");
+    }
+
+    /// Closing the cancel pipe's write end must unblock the read rather than
+    /// leaving the thread parked on the tty forever.
+    #[test]
+    fn read_hidden_is_cancellable() {
+        let (_master, slave) = openpty_pair();
+
+        let mut fds = [0 as RawFd; 2];
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0, "pipe failed");
+        let (cancel_r, cancel_w) = (fds[0], fds[1]);
+
+        let reader = std::thread::spawn(move || read_hidden(slave, Some(cancel_r)));
+
+        // Hang up the cancel pipe — poll() sees POLLHUP and bails out.
+        unsafe { libc::close(cancel_w) };
+
+        let err = reader
+            .join()
+            .expect("reader thread")
+            .expect_err("should be cancelled, not read");
+        assert_eq!(err.kind(), io::ErrorKind::Interrupted);
+    }
+}


### PR DESCRIPTION
## Problem

Items surfaced from the metadata sidecar while their provider is locked carry attribute *names* with blank values — the sidecar stores HMAC fingerprints, not plaintext. `dedup()` keyed on `(label, attribute values)`, so any two items sharing a label and attribute-key-set collapsed into one, and the losers disappeared from `SearchItems` entirely.

libsecret clients read that absence as "no such key" and store a freshly minted one over the survivor.

## Observed impact

Signal Desktop lost its database. A second `Chromium Safe Storage` item (`application=chromium`) was created on 2026-07-31; Signal's own (`application=Signal`) shares that label and attribute-key-set, so once locked the two were indistinguishable and one was dropped. On the next cold start Electron found nothing, minted a new key and overwrote Signal's — leaving `config.json`'s `encryptedKey` undecryptable and the message DB unopenable (`SQLITE_NOTADB`).

Reproduced against a locked vault before the fix:

| query | before | after |
|---|---|---|
| `SearchItems({})` | 13 of 17 items | 17 of 17 |
| `application=Signal` | 0 | 1 |
| `application=chromium` | 1 | 1 |

Three other items were being collapsed the same way (a duplicate `zed-github-account`, two `org.freedesktop.Secret.Generic` including a Bitwarden refresh token).

## Fix

Key on `attribute_hashes` when present — the fingerprints stay distinct while locked. This can only under-dedup, never over-dedup: a visible duplicate is cosmetic, a vanished item is data loss.

## Also included

`test(secret-service)`: the TTY credential path looked untestable because it takes a `RawFd`, but a pty pair works — `libc` is already a direct dependency. A pipe genuinely does not work (`tcgetattr`/`tcsetattr` return `ENOTTY`). Covers the happy path and `cancel_fd` cancellation, and documents a `TCSAFLUSH` race that makes naive versions of these tests hang forever.

## Testing

- New regression test `locked_items_dedup_on_hashes_not_blank_values`
- Two new pty tests for `read_hidden`
- Full workspace suite green