### PR TITLE
feat(cli): add `rosec unlock --gui`

### DIFF
--- a/rosec-secret-service/src/daemon/management.rs
+++ b/rosec-secret-service/src/daemon/management.rs
@@ -9,7 +9,7 @@ use zvariant::OwnedFd;
 
 use super::log_dbus_caller;
 use crate::state::ServiceState;
-use crate::unlock::{auth_provider_with_tty, unlock_with_tty};
+use crate::unlock::{CredentialSink, auth_provider_with_tty, unlock_all, unlock_with_tty};
 
 pub struct RosecManagement {
     pub(super) state: Arc<ServiceState>,
@@ -271,6 +271,48 @@ impl RosecManagement {
                 .collect()),
             Ok(Err(e)) => Err(FdoError::Failed(format!("unlock_with_tty error: {e}"))),
             Err(e) => Err(e),
+        }
+    }
+
+    /// Unlock every locked provider, prompting in `rosec-prompt` dialogs.
+    ///
+    /// Same walk and same return as `UnlockWithTty`, but needs no controlling
+    /// terminal — usable from keybindings and systemd units.
+    async fn unlock_with_prompt(
+        &self,
+        #[zbus(header)] header: Header<'_>,
+    ) -> Result<Vec<UnlockResultEntry>, FdoError> {
+        log_dbus_caller("management", "UnlockWithPrompt", &header);
+
+        // Anything on the session bus can call this, and a dialog carries no
+        // evidence of who asked for it — so name the caller on every prompt.
+        let caller = crate::prompt::resolve_caller_info(&header, &self.state.conn()).await;
+
+        // One path for the whole walk, so CancelPrompt works as it does for
+        // the spec Prompt flow.
+        let prompt_path = self.state.allocate_prompt("");
+        let state = Arc::clone(&self.state);
+        let path_for_task = prompt_path.clone();
+        let handle = self.state.spawn_on_tokio(async move {
+            let sink = CredentialSink::prompt(path_for_task, caller);
+            unlock_all(state, &sink).await
+        });
+
+        let result = handle
+            .await
+            .map_err(|e| FdoError::Failed(format!("unlock task panicked: {e}")))?;
+        self.state.finish_prompt(&prompt_path);
+
+        match result {
+            Ok(results) => Ok(results
+                .into_iter()
+                .map(|r| UnlockResultEntry {
+                    provider_id: r.provider_id,
+                    success: r.success,
+                    message: r.message,
+                })
+                .collect()),
+            Err(e) => Err(FdoError::Failed(format!("unlock_with_prompt error: {e}"))),
         }
     }
 

--- a/rosec-secret-service/src/prompt.rs
+++ b/rosec-secret-service/src/prompt.rs
@@ -343,13 +343,16 @@ async fn run_prompt_task(
                     format!("{provider_name} — two-factor authentication")
                 };
                 let fields_for_prompt = two_fa_fields.clone();
+                let caller_2fa = caller.clone();
 
                 let two_fa_result: Result<HashMap<String, Zeroizing<String>>, zbus::fdo::Error> =
                     match tokio::task::spawn_blocking(move || {
                         state_2fa.spawn_prompt_fields(
                             &prompt_path_2fa,
                             &title_2fa,
+                            "",
                             &fields_for_prompt,
+                            caller_2fa,
                         )
                     })
                     .await
@@ -614,7 +617,7 @@ async fn execute_deferred_delete(
 /// Uses `GetConnectionUnixProcessID` to get the PID, then reads
 /// `/proc/<pid>/comm` for the short name and `/proc/<pid>/exe` for the full
 /// path.  Returns `None` if the sender is unknown or the PID lookup fails.
-async fn resolve_caller_info(
+pub(crate) async fn resolve_caller_info(
     header: &zbus::message::Header<'_>,
     conn: &Connection,
 ) -> Option<CallerInfo> {

--- a/rosec-secret-service/src/state.rs
+++ b/rosec-secret-service/src/state.rs
@@ -967,7 +967,9 @@ impl ServiceState {
         self: &Arc<Self>,
         prompt_path: &str,
         title: &str,
+        message: &str,
         fields_json: &[serde_json::Value],
+        caller: Option<CallerInfo>,
     ) -> Result<HashMap<String, Zeroizing<String>>, FdoError> {
         use std::io::BufRead as _;
         use std::process::Stdio;
@@ -993,7 +995,7 @@ impl ServiceState {
             ));
         }
 
-        let json = build_prompt_fields_json(title, fields_json, &prompt_cfg);
+        let json = build_prompt_fields_json(title, message, fields_json, &prompt_cfg, caller);
 
         let mut cmd = std::process::Command::new(&program);
         // SAFETY: pre_exec runs after fork() in the child process.
@@ -2211,15 +2213,23 @@ fn format_caller_info(fmt: &str, caller: &CallerInfo) -> String {
 /// selector, TOTP code) rather than the fixed single password field.
 fn build_prompt_fields_json(
     title: &str,
+    message: &str,
     fields: &[serde_json::Value],
     cfg: &PromptConfig,
+    caller: Option<CallerInfo>,
 ) -> String {
     use serde_json::{Value, json};
     let theme = serde_json::to_value(&cfg.theme).unwrap_or_default();
+    // Unattributed, a dialog summoned over D-Bus is indistinguishable from one
+    // the user started.
+    let info = caller
+        .map(|c| format_caller_info(&cfg.info_format, &c))
+        .unwrap_or_default();
     let req: Value = json!({
         "title": title,
-        "message": "",
+        "message": message,
         "hint": "",
+        "info": info,
         "provider": "",
         "confirm_label": "Submit",
         "cancel_label": "Cancel",

--- a/rosec-secret-service/src/unlock.rs
+++ b/rosec-secret-service/src/unlock.rs
@@ -1,11 +1,10 @@
 /// In-process credential collection and unlock logic.
 ///
-/// `rosecd` receives a TTY file descriptor from the CLI client via D-Bus
-/// fd-passing (SCM_RIGHTS).  All prompting happens here — inside the daemon
-/// process — so credentials never appear in any D-Bus message payload.
+/// Prompting happens inside the daemon — via the client's TTY fd or a
+/// `rosec-prompt` dialog — so credentials never cross D-Bus.
 use std::collections::HashMap;
 use std::os::unix::io::RawFd;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Result, anyhow};
 use futures_util::future::join_all;
@@ -14,16 +13,168 @@ use zeroize::Zeroizing;
 
 use rosec_core::ProviderError;
 
-use crate::state::ServiceState;
+use crate::state::{CallerInfo, ServiceState};
 use crate::tty::{TtyField, collect_tty_on_fd, prompt_field_on_fd};
 
-/// Result of a single provider unlock attempt inside `unlock_with_tty`.
+/// Result of a single provider unlock attempt inside [`unlock_all`].
 #[derive(Debug)]
 pub struct UnlockResult {
     pub provider_id: String,
     pub success: bool,
     /// Human-readable status message (e.g. "unlocked", "wrong password", etc.).
     pub message: String,
+}
+
+/// Where credential prompts are rendered.  The unlock walk is the same either
+/// way — only the transport differs.
+pub enum CredentialSink {
+    Tty {
+        fd: RawFd,
+        /// Read end of a pipe; closing the write end aborts a blocking read.
+        cancel_fd: Option<RawFd>,
+    },
+    Prompt {
+        path: String,
+        /// A dialog has nowhere to put running commentary, so progress lines
+        /// accumulate here and ride along on the next prompt.
+        pending: Mutex<String>,
+        /// Anything on the session bus can ask for a dialog, so name who did.
+        caller: Option<CallerInfo>,
+    },
+}
+
+impl CredentialSink {
+    pub fn tty(fd: RawFd, cancel_fd: Option<RawFd>) -> Self {
+        Self::Tty { fd, cancel_fd }
+    }
+
+    pub fn prompt(path: String, caller: Option<CallerInfo>) -> Self {
+        Self::Prompt {
+            path,
+            pending: Mutex::new(String::new()),
+            caller,
+        }
+    }
+
+    /// Supplementary detail: printed on a TTY, shown in the dialog body.
+    fn notice(&self, s: &str) {
+        match self {
+            Self::Tty { fd, .. } => print_on_fd(*fd, s),
+            Self::Prompt { pending, .. } => {
+                if let Ok(mut buf) = pending.lock() {
+                    buf.push_str(s);
+                }
+            }
+        }
+    }
+
+    /// Text that is also passed to [`collect`](Self::collect) as its title.
+    /// Dropped on the dialog path, which would otherwise render it twice.
+    fn header(&self, s: &str) {
+        if let Self::Tty { fd, .. } = self {
+            print_on_fd(*fd, s);
+        }
+    }
+
+    /// Column-aligned on a TTY; a dialog is proportional, so padding there
+    /// only produces ragged lines.
+    fn list_item(&self, id: &str, name: &str) {
+        let unnamed = name.is_empty() || name == id;
+        match self {
+            Self::Tty { .. } if unnamed => self.notice(&format!("  {id}\n")),
+            Self::Tty { .. } => self.notice(&format!("  {id:<30}  ({name})\n")),
+            Self::Prompt { .. } if unnamed => self.notice(&format!("  {id}\n")),
+            Self::Prompt { .. } => self.notice(&format!("  {id} ({name})\n")),
+        }
+    }
+
+    /// Drops blank lines at either end, but never touches a line's indent — a
+    /// blanket `trim` eats it off the first line only, leaving a list with its
+    /// first entry hanging out to the left.
+    fn take_pending(&self) -> String {
+        let Self::Prompt { pending, .. } = self else {
+            return String::new();
+        };
+        let raw = pending
+            .lock()
+            .map(|mut b| std::mem::take(&mut *b))
+            .unwrap_or_default();
+        let lines: Vec<&str> = raw.lines().collect();
+        let first = lines.iter().position(|l| !l.trim().is_empty());
+        let last = lines.iter().rposition(|l| !l.trim().is_empty());
+        match (first, last) {
+            (Some(a), Some(b)) => lines[a..=b].join("\n"),
+            _ => String::new(),
+        }
+    }
+
+    /// `title` is the dialog heading and is ignored on a TTY, where
+    /// [`header`](Self::header) has already written it.  Pass `""` when the
+    /// field labels alone are clear enough.
+    async fn collect(
+        &self,
+        state: &Arc<ServiceState>,
+        title: &str,
+        fields: &[TtyField],
+    ) -> Result<HashMap<String, Zeroizing<String>>> {
+        match self {
+            Self::Tty { fd, cancel_fd } => collect_tty_on_fd(*fd, fields, *cancel_fd).await,
+            Self::Prompt { path, caller, .. } => {
+                let fields_json: Vec<serde_json::Value> =
+                    fields.iter().map(field_to_json).collect();
+                let message = self.take_pending();
+                let title = title.trim().to_string();
+                let state = Arc::clone(state);
+                let path = path.clone();
+                let caller = caller.clone();
+                tokio::task::spawn_blocking(move || {
+                    state.spawn_prompt_fields(&path, &title, &message, &fields_json, caller)
+                })
+                .await
+                .map_err(|e| anyhow!("prompt task panicked: {e}"))?
+                .map_err(|e| anyhow!("{e}"))
+            }
+        }
+    }
+
+    async fn prompt_field(
+        &self,
+        state: &Arc<ServiceState>,
+        label: &str,
+        placeholder: &str,
+        kind: &str,
+    ) -> Result<Zeroizing<String>> {
+        match self {
+            Self::Tty { fd, cancel_fd } => {
+                prompt_field_on_fd(*fd, label, placeholder, kind, *cancel_fd).await
+            }
+            Self::Prompt { .. } => {
+                let field = TtyField {
+                    id: "__confirm".to_string(),
+                    label: label.to_string(),
+                    kind: kind.to_string(),
+                    placeholder: placeholder.to_string(),
+                };
+                // `label` is the field's own label; the notices explain why.
+                let map = self
+                    .collect(state, "", std::slice::from_ref(&field))
+                    .await?;
+                Ok(map
+                    .get("__confirm")
+                    .cloned()
+                    .unwrap_or_else(|| Zeroizing::new(String::new())))
+            }
+        }
+    }
+}
+
+fn field_to_json(f: &TtyField) -> serde_json::Value {
+    serde_json::json!({
+        "id": f.id,
+        "label": f.label,
+        "kind": f.kind,
+        "placeholder": f.placeholder,
+    })
 }
 
 /// Build the success message for a provider unlock, reflecting whether the
@@ -46,22 +197,32 @@ async fn unlock_success_message(state: &ServiceState, provider_id: &str, suffix:
     }
 }
 
-/// Unlock all locked providers using credentials prompted on `tty_fd`.
+/// Unlock all locked providers, prompting on `tty_fd`.
+///
+/// Thin wrapper over [`unlock_all`]; see it for the walk itself.
+///
+/// `cancel_fd` is the read end of a pipe; closing the write end from outside
+/// this function will abort any in-progress blocking TTY read.  Pass `None`
+/// if cancellation is not needed.
+pub async fn unlock_with_tty(
+    state: Arc<ServiceState>,
+    tty_fd: RawFd,
+    cancel_fd: Option<RawFd>,
+) -> Result<Vec<UnlockResult>> {
+    unlock_all(state, &CredentialSink::tty(tty_fd, cancel_fd)).await
+}
+
+/// Unlock all locked providers, prompting through `sink`.
 ///
 /// Implements the opportunistic sweep: if there are multiple locked providers,
 /// prompts once and tries the same password against all of them.  Any that
 /// fail (wrong password) or require registration are handled individually
 /// afterwards.
 ///
-/// `cancel_fd` is the read end of a pipe; closing the write end from outside
-/// this function will abort any in-progress blocking TTY read.  Pass `None`
-/// if cancellation is not needed.
-///
 /// This function must be called from a Tokio task context.
-pub async fn unlock_with_tty(
+pub async fn unlock_all(
     state: Arc<ServiceState>,
-    tty_fd: RawFd,
-    cancel_fd: Option<RawFd>,
+    sink: &CredentialSink,
 ) -> Result<Vec<UnlockResult>> {
     let providers = state.providers_ordered();
     let mut locked: Vec<_> = Vec::new();
@@ -88,8 +249,7 @@ pub async fn unlock_with_tty(
         let id = provider.id().to_string();
         let fields = provider_auth_fields(provider.as_ref());
         let _password =
-            auth_provider_with_tty_inner(&state, tty_fd, cancel_fd, &id, &fields, None, false)
-                .await?;
+            auth_provider_with_tty_inner(&state, sink, &id, &fields, None, false).await?;
         // Sync immediately so on_sync_succeeded callbacks fire (e.g. SSH rebuild).
         if let Err(e) = state.try_sync_provider(&id).await {
             debug!(provider = %id, "post-unlock sync failed: {e}");
@@ -106,16 +266,10 @@ pub async fn unlock_with_tty(
     }
 
     // Multiple providers — print a header listing them all, then prompt once.
-    print_on_fd(tty_fd, "\n");
-    print_on_fd(tty_fd, &format!("Unlocking {} providers:\n", locked.len()));
+    sink.notice("\n");
+    sink.header(&format!("Unlocking {} providers:\n", locked.len()));
     for b in &locked {
-        let id = b.id();
-        let name = b.name();
-        if name.is_empty() || name == id {
-            print_on_fd(tty_fd, &format!("  {id}\n"));
-        } else {
-            print_on_fd(tty_fd, &format!("  {id:<30}  ({name})\n"));
-        }
+        sink.list_item(b.id(), b.name());
     }
 
     // Use the first provider's password field descriptor as representative for
@@ -125,7 +279,13 @@ pub async fn unlock_with_tty(
         .first()
         .ok_or_else(|| anyhow!("provider returned no auth fields"))?;
 
-    let collected = collect_tty_on_fd(tty_fd, std::slice::from_ref(pw_field), cancel_fd).await?;
+    let collected = sink
+        .collect(
+            &state,
+            &format!("Unlocking {} providers", locked.len()),
+            std::slice::from_ref(pw_field),
+        )
+        .await?;
 
     // Extract the raw password value.  The collected map is keyed by the first
     // provider's field ID, but other providers may use a different field name
@@ -197,7 +357,7 @@ pub async fn unlock_with_tty(
                 need_2fa.push((id, raw_password.clone()));
             }
             Err(ProviderError::AuthFailed) => {
-                print_on_fd(tty_fd, &format!("  {id}: wrong password (skipped)\n"));
+                sink.notice(&format!("  {id}: wrong password (skipped)\n"));
                 results.push(UnlockResult {
                     provider_id: id.clone(),
                     success: false,
@@ -205,7 +365,7 @@ pub async fn unlock_with_tty(
                 });
             }
             Err(ProviderError::Unavailable(ref reason)) => {
-                print_on_fd(tty_fd, &format!("  {id}: {reason}\n"));
+                sink.notice(&format!("  {id}: {reason}\n"));
                 results.push(UnlockResult {
                     provider_id: id.clone(),
                     success: false,
@@ -213,12 +373,9 @@ pub async fn unlock_with_tty(
                 });
             }
             Err(ProviderError::NotFound) => {
-                print_on_fd(
-                    tty_fd,
-                    &format!(
-                        "  {id}: not available — run `rosec provider auth {id}` to initialise\n"
-                    ),
-                );
+                sink.notice(&format!(
+                    "  {id}: not available — run `rosec provider auth {id}` to initialise\n"
+                ));
                 results.push(UnlockResult {
                     provider_id: id.clone(),
                     success: false,
@@ -227,7 +384,7 @@ pub async fn unlock_with_tty(
             }
             Err(ProviderError::Other(ref e)) => {
                 let hint = crate::state::user_facing_hint(e);
-                print_on_fd(tty_fd, &format!("  {id}: {hint}\n"));
+                sink.notice(&format!("  {id}: {hint}\n"));
                 results.push(UnlockResult {
                     provider_id: id.clone(),
                     success: false,
@@ -255,16 +412,8 @@ pub async fn unlock_with_tty(
         // Build prefill map using this provider's own password field name.
         let mut prefill = HashMap::new();
         prefill.insert(pw_field_id, password);
-        let _password = auth_provider_with_tty_inner(
-            &state,
-            tty_fd,
-            cancel_fd,
-            &id,
-            &fields,
-            Some(prefill),
-            false,
-        )
-        .await?;
+        let _password =
+            auth_provider_with_tty_inner(&state, sink, &id, &fields, Some(prefill), false).await?;
         if let Err(e) = state.try_sync_provider(&id).await {
             debug!(provider = %id, "post-unlock sync failed: {e}");
         }
@@ -286,11 +435,11 @@ pub async fn unlock_with_tty(
             (b.password_field().id.to_string(), b.name().to_string())
         };
         // Print a header so the user knows which provider needs 2FA.
-        print_on_fd(tty_fd, "\n");
+        sink.notice("\n");
         if name.is_empty() || name == id {
-            print_on_fd(tty_fd, &format!("Unlocking {id}\n"));
+            sink.notice(&format!("Unlocking {id}\n"));
         } else {
-            print_on_fd(tty_fd, &format!("Unlocking {id}  ({name})\n"));
+            sink.notice(&format!("Unlocking {id}  ({name})\n"));
         }
         let mut prefill = HashMap::new();
         prefill.insert(pw_field_id, password);
@@ -300,16 +449,8 @@ pub async fn unlock_with_tty(
                 .ok_or_else(|| anyhow!("provider '{id}' not found"))?;
             provider_auth_fields(b.as_ref())
         };
-        let _password = auth_provider_with_tty_inner(
-            &state,
-            tty_fd,
-            cancel_fd,
-            &id,
-            &fields,
-            Some(prefill),
-            false,
-        )
-        .await?;
+        let _password =
+            auth_provider_with_tty_inner(&state, sink, &id, &fields, Some(prefill), false).await?;
         if let Err(e) = state.try_sync_provider(&id).await {
             debug!(provider = %id, "post-unlock sync failed: {e}");
         }
@@ -330,8 +471,7 @@ pub async fn unlock_with_tty(
             provider_auth_fields(b.as_ref())
         };
         let _password =
-            auth_provider_with_tty_inner(&state, tty_fd, cancel_fd, &id, &fields, None, false)
-                .await?;
+            auth_provider_with_tty_inner(&state, sink, &id, &fields, None, false).await?;
         if let Err(e) = state.try_sync_provider(&id).await {
             debug!(provider = %id, "post-unlock sync failed: {e}");
         }
@@ -350,23 +490,41 @@ pub async fn unlock_with_tty(
     Ok(results)
 }
 
-/// Authenticate a single provider using credentials prompted on `tty_fd`.
+/// Authenticate a single provider, prompting on `tty_fd`.
 ///
-/// This is the `AuthProviderWithTty` D-Bus method implementation.
-/// Must be called from a Tokio task context.
+/// This is the `AuthProviderWithTty` D-Bus method implementation; a thin
+/// wrapper over [`auth_provider_via`].
 ///
 /// `cancel_fd` is the read end of a pipe; closing the write end from outside
 /// this function will abort any in-progress blocking TTY read.  Pass `None`
 /// if cancellation is not needed.
+pub async fn auth_provider_with_tty(
+    state: Arc<ServiceState>,
+    tty_fd: RawFd,
+    cancel_fd: Option<RawFd>,
+    provider_id: &str,
+    force: bool,
+) -> Result<()> {
+    auth_provider_via(
+        state,
+        &CredentialSink::tty(tty_fd, cancel_fd),
+        provider_id,
+        force,
+    )
+    .await
+}
+
+/// Authenticate a single provider, prompting through `sink`.
+///
+/// Must be called from a Tokio task context.
 ///
 /// When `force` is `true`, the normal unlock attempt is skipped and the
 /// registration flow is entered unconditionally.  This allows re-registering
 /// provider credentials (e.g. rotating a Bitwarden SM access token or
 /// re-registering a Bitwarden PM device) without deleting stored state first.
-pub async fn auth_provider_with_tty(
+pub async fn auth_provider_via(
     state: Arc<ServiceState>,
-    tty_fd: RawFd,
-    cancel_fd: Option<RawFd>,
+    sink: &CredentialSink,
     provider_id: &str,
     force: bool,
 ) -> Result<()> {
@@ -377,8 +535,7 @@ pub async fn auth_provider_with_tty(
         provider_auth_fields(b.as_ref())
     };
     let password =
-        auth_provider_with_tty_inner(&state, tty_fd, cancel_fd, provider_id, &fields, None, force)
-            .await?;
+        auth_provider_with_tty_inner(&state, sink, provider_id, &fields, None, force).await?;
     // auth_provider (called by auth_provider_with_tty_inner) already
     // called mark_provider_unlocked + touch_activity.
     // Sync immediately so on_sync_succeeded callbacks fire (e.g. SSH rebuild).
@@ -418,8 +575,7 @@ pub async fn auth_provider_with_tty(
 /// can pass it to `opportunistic_sweep` if desired.
 async fn auth_provider_with_tty_inner(
     state: &Arc<ServiceState>,
-    tty_fd: RawFd,
-    cancel_fd: Option<RawFd>,
+    sink: &CredentialSink,
     provider_id: &str,
     fields: &[TtyField],
     prefill: Option<HashMap<String, Zeroizing<String>>>,
@@ -454,36 +610,33 @@ async fn auth_provider_with_tty_inner(
         // Credentials already collected by the sweep — skip prompting.
         existing
     } else {
-        print_on_fd(tty_fd, "\n");
+        sink.notice("\n");
         let b = state
             .provider_by_id(provider_id)
             .ok_or_else(|| anyhow!("provider '{provider_id}' not found"))?;
         let name = b.name().to_string();
-        if name.is_empty() || name == provider_id {
-            if is_token_auth {
-                print_on_fd(tty_fd, &format!("Authenticating {provider_id}\n"));
-            } else {
-                print_on_fd(tty_fd, &format!("Unlocking {provider_id}\n"));
-            }
-        } else if is_token_auth {
-            print_on_fd(tty_fd, &format!("Authenticating {provider_id}  ({name})\n"));
+        let verb = if is_token_auth {
+            "Authenticating"
         } else {
-            print_on_fd(tty_fd, &format!("Unlocking {provider_id}  ({name})\n"));
-        }
+            "Unlocking"
+        };
+        let title = if name.is_empty() || name == provider_id {
+            format!("{verb} {provider_id}")
+        } else {
+            format!("{verb} {provider_id}  ({name})")
+        };
+        sink.header(&format!("{title}\n"));
 
-        collect_tty_on_fd(tty_fd, fields, cancel_fd).await?
+        sink.collect(state, &title, fields).await?
     };
 
     // If the provider requires new-password confirmation (e.g. creating a new
     // local vault where nothing is stored yet to verify against), prompt the
     // user to type the password a second time before proceeding.
     if needs_confirmation {
-        print_on_fd(tty_fd, "\n");
-        print_on_fd(
-            tty_fd,
-            "This vault does not exist yet and will be created with this password.\n",
-        );
-        print_on_fd(tty_fd, "Please confirm your password:\n\n");
+        sink.notice("\n");
+        sink.notice("This vault does not exist yet and will be created with this password.\n");
+        sink.notice("Please confirm your password:\n\n");
         for field in fields
             .iter()
             .filter(|f| f.kind == "password" || f.kind == "secret")
@@ -494,12 +647,13 @@ async fn auth_provider_with_tty_inner(
                 .unwrap_or_else(|| Zeroizing::new(String::new()));
             loop {
                 let confirm_label = format!("Confirm {}", field.label);
-                let entry =
-                    prompt_field_on_fd(tty_fd, &confirm_label, "", &field.kind, cancel_fd).await?;
+                let entry = sink
+                    .prompt_field(state, &confirm_label, "", &field.kind)
+                    .await?;
                 if entry.as_str() == original.as_str() {
                     break;
                 }
-                print_on_fd(tty_fd, "Does not match — please try again.\n\n");
+                sink.notice("Does not match — please try again.\n\n");
             }
         }
     }
@@ -539,10 +693,10 @@ async fn auth_provider_with_tty_inner(
         let chosen = if text_methods.len() == 1 {
             text_methods[0]
         } else {
-            print_on_fd(tty_fd, "\nTwo-factor authentication required.\n");
-            print_on_fd(tty_fd, "Available methods:\n");
+            sink.header("\nTwo-factor authentication required.\n");
+            sink.notice("Available methods:\n");
             for (i, m) in text_methods.iter().enumerate() {
-                print_on_fd(tty_fd, &format!("  [{}] {}\n", i + 1, m.label));
+                sink.notice(&format!("  [{}] {}\n", i + 1, m.label));
             }
             let choice_field = vec![TtyField {
                 id: "__2fa_choice".to_string(),
@@ -550,7 +704,13 @@ async fn auth_provider_with_tty_inner(
                 kind: "text".to_string(),
                 placeholder: "1".to_string(),
             }];
-            let choice_map = collect_tty_on_fd(tty_fd, &choice_field, cancel_fd).await?;
+            let choice_map = sink
+                .collect(
+                    state,
+                    &format!("{provider_id} — two-factor authentication"),
+                    &choice_field,
+                )
+                .await?;
             let choice_str = choice_map
                 .get("__2fa_choice")
                 .map(|v| v.as_str())
@@ -559,7 +719,7 @@ async fn auth_provider_with_tty_inner(
             text_methods.get(idx).copied().unwrap_or(text_methods[0])
         };
 
-        print_on_fd(tty_fd, &format!("\n{}\n", chosen.label));
+        sink.notice(&format!("\n{}\n", chosen.label));
 
         let token_field = vec![TtyField {
             id: "__2fa_token".to_string(),
@@ -567,7 +727,15 @@ async fn auth_provider_with_tty_inner(
             kind: "secret".to_string(),
             placeholder: String::new(),
         }];
-        let token_map = collect_tty_on_fd(tty_fd, &token_field, cancel_fd).await?;
+        // The chosen method's label went out through notice() just above, so on
+        // the dialog path it arrives as part of the heading.
+        let token_map = sink
+            .collect(
+                state,
+                &format!("{provider_id} — two-factor authentication"),
+                &token_field,
+            )
+            .await?;
 
         // Inject the chosen method + token into cred_map and loop back to
         // try_auth, which will resend the credentials with the 2FA fields.
@@ -592,9 +760,9 @@ async fn auth_provider_with_tty_inner(
             anyhow!("provider reported registration_required but has no registration_info")
         })?;
 
-        print_on_fd(tty_fd, "\n");
-        print_on_fd(tty_fd, &format!("{}\n", reg_info.instructions));
-        print_on_fd(tty_fd, "\n");
+        sink.notice("\n");
+        sink.notice(&format!("{}\n", reg_info.instructions));
+        sink.notice("\n");
 
         // Collect registration-specific fields (e.g. the SM access token).
         let reg_fields: Vec<TtyField> = reg_info
@@ -608,7 +776,9 @@ async fn auth_provider_with_tty_inner(
             })
             .collect();
 
-        let reg_extra = collect_tty_on_fd(tty_fd, &reg_fields, cancel_fd).await?;
+        let reg_extra = sink
+            .collect(state, &format!("{provider_id} — registration"), &reg_fields)
+            .await?;
         cred_map.extend(reg_extra);
 
         state
@@ -634,7 +804,11 @@ async fn auth_provider_with_tty_inner(
     // cred_map is dropped here; all Zeroizing<String> values are scrubbed.
     drop(cred_map);
 
-    info!(provider = %provider_id, "provider authenticated via AuthProviderWithTty");
+    let via = match sink {
+        CredentialSink::Tty { .. } => "tty",
+        CredentialSink::Prompt { .. } => "prompt",
+    };
+    info!(provider = %provider_id, via, "provider authenticated");
     Ok(password)
 }
 

--- a/rosec/src/cli.rs
+++ b/rosec/src/cli.rs
@@ -166,7 +166,15 @@ EXAMPLES:
     Lock,
 
     /// Unlock (triggers GUI/TTY prompt)
-    Unlock,
+    Unlock {
+        /// Prompt in `rosec-prompt` dialogs rather than on this terminal.
+        ///
+        /// Same walk as the terminal form — including registration and
+        /// second-factor rounds such as Bitwarden 2FA/TOTP — but needs no
+        /// controlling TTY, so it works from keybindings and systemd units.
+        #[arg(long)]
+        gui: bool,
+    },
 
     /// Activate rosec as the Secret Service provider
     #[command(

--- a/rosec/src/main.rs
+++ b/rosec/src/main.rs
@@ -64,7 +64,7 @@ async fn main() -> Result<()> {
         Commands::Totp(cmd) => totp::dispatch(cmd).await,
         Commands::Inspect(args) => inspect::run(args).await,
         Commands::Lock => lock::run().await,
-        Commands::Unlock => unlock::run().await,
+        Commands::Unlock { gui } => unlock::run(gui).await,
         Commands::Enable(args) => enable::cmd_enable(args),
         Commands::Disable(args) => enable::cmd_disable(args),
     }

--- a/rosec/src/unlock.rs
+++ b/rosec/src/unlock.rs
@@ -1,10 +1,11 @@
-//! `rosec unlock` — unlock all syncable providers via TTY fd-passing.
+//! `rosec unlock` — unlock all syncable providers via TTY fd-passing, or via
+//! the graphical prompt with `--gui`.
 
 use anyhow::Result;
 
 use crate::{ProviderEntry, conn, open_tty_owned_fd};
 
-pub async fn run() -> Result<()> {
+pub async fn run(gui: bool) -> Result<()> {
     let conn = conn().await?;
 
     let proxy = zbus::Proxy::new(
@@ -30,19 +31,29 @@ pub async fn run() -> Result<()> {
         return Ok(());
     }
 
-    // Pass the caller's TTY fd to the daemon via D-Bus fd-passing.
-    // All credential prompting happens inside rosecd — credentials never
-    // appear in any D-Bus message payload.
-    let tty_fd = open_tty_owned_fd()?;
-    eprintln!("Unlocking…");
     type ResultEntry = (String, bool, String); // (provider_id, success, message)
-    let results: Vec<ResultEntry> = proxy.call("UnlockWithTty", &(tty_fd,)).await?;
+
+    // Both methods run the same walk inside rosecd and return the same tuples;
+    // they differ only in where the daemon renders its prompts.
+    let results: Vec<ResultEntry> = if gui {
+        proxy.call("UnlockWithPrompt", &()).await?
+    } else {
+        // Pass the caller's TTY fd to the daemon via D-Bus fd-passing.
+        // All credential prompting happens inside rosecd — credentials never
+        // appear in any D-Bus message payload.
+        let tty_fd = open_tty_owned_fd()?;
+        eprintln!("Unlocking…");
+        proxy.call("UnlockWithTty", &(tty_fd,)).await?
+    };
 
     for (id, success, message) in &results {
         if *success {
             println!("  {id}: {message}");
+        } else if gui {
+            // The TTY path already printed failures inline on the terminal;
+            // a dialog leaves no such trace, so surface them here.
+            println!("  {id}: {message}");
         }
-        // Failures are already printed inline on the TTY by the daemon.
     }
 
     Ok(())


### PR DESCRIPTION
## What

`rosec unlock --gui` renders the unlock prompts as `rosec-prompt` dialogs instead of writing to the caller's terminal, so unlocking works with no controlling TTY — from a keybinding, a launcher, or a systemd unit.

## How

Credential I/O in `unlock.rs` went through exactly two primitives (`print_on_fd`, `collect_tty_on_fd`) threaded as a `(tty_fd, cancel_fd)` pair. Those are now behind a `CredentialSink` with `Tty` and `Prompt` variants.

`unlock_with_tty` and `auth_provider_with_tty` remain as thin wrappers constructing the `Tty` sink, so **the terminal path is byte-for-byte what it was**: same provider ordering, same parallel shared-password sweep, same registration / 2FA / individual buckets, same messages.

Because it is the same walk, providers needing their own second factor are handled on both paths — Bitwarden's 2FA method chooser and TOTP code appear as follow-up dialogs rather than being skipped.

### Why not `Service.Unlock`

`Service.Unlock` takes a *collection*, and per spec a collection counts as unlocked once any one provider behind it is — so only one provider would ever be prompted. The rest fall to `opportunistic_sweep`, which replays that same password and discards `TwoFactorRequired`. A provider with its own second factor would stay locked, which is exactly the case this is for.

## Security

- **Credentials still never cross D-Bus.** `UnlockWithPrompt` takes no arguments and returns only `(provider_id, success, message)`. The password is read by the `rosec-prompt` subprocess inside the daemon, exactly as the TTY path reads it from the passed fd, and stays in `Zeroizing` throughout.
- **Prompts name the calling process.** `spawn_prompt_fields` previously took no caller and `build_prompt_fields_json` emitted no `info` field, so dialogs from it were unattributed. That was tolerable for the 2FA follow-up (it only appears mid-flow after a password the user initiated) but not for a primary password prompt that anything on the session bus can summon by calling `UnlockWithPrompt` with no arguments. Both call sites now pass `CallerInfo`, so `info_format` renders on every dialog — **this also fixes the pre-existing gap on the 2FA prompt**.
- Nothing secret can reach the dialog body: all `notice`/`header`/`list_item` call sites carry provider ids, names, static strings, 2FA method labels, registration instructions or curated error hints. `user_facing_hint` falls back to `"provider error — see journal for details"` rather than echoing raw errors.

Note this makes a malicious prompt *visible*, not impossible — `org.rosec.Daemon` still has no authorization, as before this branch.

## Presentation

Informational output splits three ways, because a terminal and a dialog want different things:

| | purpose |
|---|---|
| `header()` | text that is also `collect()`'s title — the TTY needs it written out; the dialog shows it as the title already and would otherwise render it twice |
| `notice()` | supplementary detail — the TTY prints it; the dialog carries it in the message body, rendered as ordinary text rather than picking up heading styling |
| `list_item()` | one provider in a list — fixed-width columns on a terminal, unpadded on a dialog, which is proportional and wraps |

`spawn_prompt_fields` gains a `message` parameter to carry that body; the prompt protocol already had the field, it was being sent empty.

## Testing

Verified end to end against:

- an **isolated daemon on a private bus** — vault creation, confirm-password round, provider unlocked, `via="prompt"` logged
- a **live five-provider session** — shared-password sweep, per-provider failures reported, and a Bitwarden TOTP round (`bitwarden-pm: unlocked (2FA)`)
- caller attribution confirmed rendering on the dialog

`cargo fmt`, `cargo clippy --workspace --all-targets` and the full workspace test suite are green.

## Follow-ups (not in this PR)

- `AuthProviderWithPrompt` — single-provider GUI auth, the companion to `AuthProviderWithTty`
- A provider whose password differs from the first one prompted reports `wrong password` and is skipped rather than prompted individually. Pre-existing on both paths; changing it is a behaviour change worth deciding separately.